### PR TITLE
fix: replace colons in archive filename for Windows/SMB compatibility

### DIFF
--- a/custom_components/supernotify/notification.py
+++ b/custom_components/supernotify/notification.py
@@ -591,7 +591,7 @@ class Notification(ArchivableObject):
 
     def base_filename(self) -> str:
         """ArchiveableObject implementation"""
-        return f"{self.created.isoformat()[:16]}_{self.id}"
+        return f"{self.created.isoformat()[:16].replace(':', '-')}_{self.id}"
 
     def delivery_data(self, delivery_name: str) -> dict[str, Any]:
         delivery_override: DeliveryCustomization | None = self.delivery_overrides.get(delivery_name)


### PR DESCRIPTION
Archive filenames contain colons (e.g. `2026-03-16T22:52_...json`) which are 
invalid characters in Windows filenames. Files are created correctly on Linux 
but are completely inaccessible when browsing the HA config share via SMB/Windows.

**Fix:** Replace `:` with `-` in `base_filename()` so files are named 
`2026-03-16T22-52_...json` — visible and openable on Windows without errors.

**Impact:** No functional change — only affects filename format. 
Existing files with `:` remain on disk (Linux can still read them).