### PR TITLE
feat: enhance mobile_push transport with critical notifications, TTS, tags and Android commands

### DIFF
--- a/custom_components/supernotify/transports/mobile_push.py
+++ b/custom_components/supernotify/transports/mobile_push.py
@@ -89,10 +89,10 @@ _LOGGER = logging.getLogger(__name__)
 # iOS interruption_level mapping from SuperNotify priority
 IOS_INTERRUPTION_MAP: dict[str, str] = {
     const.PRIORITY_CRITICAL: "critical",
-    const.PRIORITY_HIGH:     "time-sensitive",
-    const.PRIORITY_MEDIUM:   "active",
-    const.PRIORITY_LOW:      "passive",
-    const.PRIORITY_MINIMUM:  "passive",
+    const.PRIORITY_HIGH: "time-sensitive",
+    const.PRIORITY_MEDIUM: "active",
+    const.PRIORITY_LOW: "passive",
+    const.PRIORITY_MINIMUM: "passive",
 }
 
 # Android FCM TTL auto-set for critical priority (0 = instant, no FCM caching)
@@ -151,25 +151,25 @@ class MobilePushTransport(Transport):
         """
         return {
             # iOS
-            "critical_level_ios":        raw_data.pop("push_critical_level_ios", None),
-            "subtitle":                  raw_data.pop("push_subtitle", None),
+            "critical_level_ios": raw_data.pop("push_critical_level_ios", None),
+            "subtitle": raw_data.pop("push_subtitle", None),
             # Android critical
-            "critical_ttl":              raw_data.pop("push_critical_ttl", None),
+            "critical_ttl": raw_data.pop("push_critical_ttl", None),
             "critical_android_priority": raw_data.pop("push_critical_android_priority", None),
-            "channel_override":          raw_data.pop("push_channel_override", None),
-            "alarm_stream":              raw_data.pop("push_alarm_stream", False),
-            "alarm_stream_max":          raw_data.pop("push_alarm_stream_max", False),
+            "channel_override": raw_data.pop("push_channel_override", None),
+            "alarm_stream": raw_data.pop("push_alarm_stream", False),
+            "alarm_stream_max": raw_data.pop("push_alarm_stream_max", False),
             # Android TTS
-            "tts_text":                  raw_data.pop("push_tts_text", None),
-            "tts_locale":                raw_data.pop("push_tts_locale", None),
-            "tts_engine":                raw_data.pop("push_tts_engine", None),
+            "tts_text": raw_data.pop("push_tts_text", None),
+            "tts_locale": raw_data.pop("push_tts_locale", None),
+            "tts_engine": raw_data.pop("push_tts_engine", None),
             # Android Notification Commands
-            "command_screen_on":         raw_data.pop("push_command_screen_on", None),
-            "command_dnd":               raw_data.pop("push_command_dnd", None),
-            "command_ringer_mode":       raw_data.pop("push_command_ringer_mode", None),
+            "command_screen_on": raw_data.pop("push_command_screen_on", None),
+            "command_dnd": raw_data.pop("push_command_dnd", None),
+            "command_ringer_mode": raw_data.pop("push_command_ringer_mode", None),
             # Cross-platform
-            "notification_tag":          raw_data.pop("push_notification_tag", None),
-            "clear_notification":        raw_data.pop("push_clear_notification", False),
+            "notification_tag": raw_data.pop("push_notification_tag", None),
+            "clear_notification": raw_data.pop("push_clear_notification", False),
         }
 
     def _apply_android_payload(

--- a/custom_components/supernotify/transports/mobile_push.py
+++ b/custom_components/supernotify/transports/mobile_push.py
@@ -65,7 +65,6 @@ from custom_components.supernotify.const import (
     OPTION_TARGET_CATEGORIES,
     TRANSPORT_MOBILE_PUSH,
 )
-from custom_components.supernotify.media_grab import grab_image
 from custom_components.supernotify.model import (
     CommandType,
     DebugTrace,
@@ -299,8 +298,11 @@ class MobilePushTransport(Transport):
 
         if camera_entity_id:
             data["entity_id"] = camera_entity_id
-            # Retrieve processed camera image via grab_image() pipeline (v1.14.0+)
-            image_path = await grab_image(envelope.notification, envelope.delivery, self.context)
+            # Retrieve processed camera image via envelope.grab_image() helper
+            # (v1.14.0+). Direct call to grab_image(envelope.notification, ...)
+            # would AttributeError because the attribute is private (_notification);
+            # the envelope helper accesses it correctly.
+            image_path = await envelope.grab_image()
             if image_path:
                 data["image"] = str(image_path)
         if clip_url:

--- a/custom_components/supernotify/transports/mobile_push.py
+++ b/custom_components/supernotify/transports/mobile_push.py
@@ -1,3 +1,41 @@
+"""Mobile App Companion transport for SuperNotify.
+
+Sends push notifications to HA Companion App on iOS and Android devices.
+Supports per-device delivery with automatic snooze on failure.
+
+Priority mapping (auto, overridable via push_critical_level_ios):
+    critical  → iOS: interruption_level=critical  + Android: ttl=0
+    high      → iOS: interruption_level=time-sensitive
+    medium    → iOS: interruption_level=active    (default)
+    low       → iOS: interruption_level=passive
+    minimum   → iOS: interruption_level=passive
+
+New data keys (all optional):
+    push_critical_level_ios     str   iOS interruption_level override
+                                      ("passive","active","time-sensitive","critical")
+                                      If omitted, auto-mapped from SuperNotify priority.
+    push_critical_ttl           int   Android FCM TTL in ms (0=no caching/instant).
+                                      Auto-set to 0 for critical priority if not set.
+    push_critical_android_priority int  Android FCM priority override (1=min, 5=max).
+    push_subtitle               str   iOS subtitle (line between title and message, iOS 10+)
+    push_notification_tag       str   Notification tag for replacement (iOS) / grouping (Android)
+    push_clear_notification     bool  Send clear_notification to dismiss previous same-tag notification.
+                                      Requires push_notification_tag to be set.
+    push_tts_text               str   Android TTS text read aloud on device (Android 8+).
+                                      If omitted, push TTS is not activated.
+    push_tts_locale             str   BCP-47 language for TTS (e.g. "it-IT", "en-US").
+                                      Only used when push_tts_text is set.
+    push_tts_engine             str   TTS engine package (e.g. "com.google.android.tts").
+                                      Only used when push_tts_text is set.
+    push_command_screen_on      bool  Android: turn on device screen on delivery (Android 8+)
+    push_command_dnd            str   Android: change Do Not Disturb ("toggle","off","on")
+    push_command_ringer_mode    str   Android: change ringer mode ("silent","vibrate","normal")
+    push_channel_override       str   Android notification channel override (e.g. "alarm","general")
+    push_alarm_stream           bool  Android: route audio through alarm stream (interrupts DND/silent)
+    push_alarm_stream_max       bool  Android: alarm stream at maximum device volume
+
+"""
+
 from __future__ import annotations
 
 import logging
@@ -27,6 +65,7 @@ from custom_components.supernotify.const import (
     OPTION_TARGET_CATEGORIES,
     TRANSPORT_MOBILE_PUSH,
 )
+from custom_components.supernotify.media_grab import grab_image
 from custom_components.supernotify.model import (
     CommandType,
     DebugTrace,
@@ -39,15 +78,25 @@ from custom_components.supernotify.model import (
     TransportConfig,
     TransportFeature,
 )
-from custom_components.supernotify.transport import (
-    Transport,
-)
+from custom_components.supernotify.transport import Transport
 
 if TYPE_CHECKING:
     from custom_components.supernotify.envelope import Envelope
     from custom_components.supernotify.hass_api import HomeAssistantAPI
 
 _LOGGER = logging.getLogger(__name__)
+
+# iOS interruption_level mapping from SuperNotify priority
+IOS_INTERRUPTION_MAP: dict[str, str] = {
+    const.PRIORITY_CRITICAL: "critical",
+    const.PRIORITY_HIGH:     "time-sensitive",
+    const.PRIORITY_MEDIUM:   "active",
+    const.PRIORITY_LOW:      "passive",
+    const.PRIORITY_MINIMUM:  "passive",
+}
+
+# Android FCM TTL auto-set for critical priority (0 = instant, no FCM caching)
+ANDROID_CRITICAL_TTL = 0
 
 
 class MobilePushTransport(Transport):
@@ -66,6 +115,7 @@ class MobilePushTransport(Transport):
             | TransportFeature.ACTIONS
             | TransportFeature.IMAGES
             | TransportFeature.VIDEO
+            | TransportFeature.SNAPSHOT_IMAGE
         )
 
     def extra_attributes(self) -> dict[str, Any]:
@@ -90,6 +140,83 @@ class MobilePushTransport(Transport):
 
     def validate_action(self, action: str | None) -> bool:
         return action is None
+
+    def _extract_push_data(self, raw_data: dict[str, Any]) -> dict[str, Any]:
+        """Extract and remove SuperNotify-specific push_* keys from raw_data.
+
+        Modifies raw_data in-place via pop().
+        After this call, raw_data contains only passthrough keys for the Companion App.
+
+        Returns a dict with all extracted push_* values (None if not provided).
+        """
+        return {
+            # iOS
+            "critical_level_ios":        raw_data.pop("push_critical_level_ios", None),
+            "subtitle":                  raw_data.pop("push_subtitle", None),
+            # Android critical
+            "critical_ttl":              raw_data.pop("push_critical_ttl", None),
+            "critical_android_priority": raw_data.pop("push_critical_android_priority", None),
+            "channel_override":          raw_data.pop("push_channel_override", None),
+            "alarm_stream":              raw_data.pop("push_alarm_stream", False),
+            "alarm_stream_max":          raw_data.pop("push_alarm_stream_max", False),
+            # Android TTS
+            "tts_text":                  raw_data.pop("push_tts_text", None),
+            "tts_locale":                raw_data.pop("push_tts_locale", None),
+            "tts_engine":                raw_data.pop("push_tts_engine", None),
+            # Android Notification Commands
+            "command_screen_on":         raw_data.pop("push_command_screen_on", None),
+            "command_dnd":               raw_data.pop("push_command_dnd", None),
+            "command_ringer_mode":       raw_data.pop("push_command_ringer_mode", None),
+            # Cross-platform
+            "notification_tag":          raw_data.pop("push_notification_tag", None),
+            "clear_notification":        raw_data.pop("push_clear_notification", False),
+        }
+
+    def _apply_android_payload(
+        self,
+        data: dict[str, Any],
+        push_data: dict[str, Any],
+        priority: str | None,
+    ) -> None:
+        """Apply Android-specific fields to the notification data dict.
+
+        Android fields live flat in data{}, not inside the push{} sub-dict.
+        """
+        # Channel override (Android 8+, determines sound/vibration/LED)
+        if push_data["channel_override"]:
+            data["channel"] = push_data["channel_override"]
+
+        # Alarm stream: routes audio through alarm stream, interrupts DND/silent
+        if push_data["alarm_stream"]:
+            data["alarm_stream"] = True
+            if push_data["alarm_stream_max"]:
+                data["alarm_stream_max"] = True
+
+        # FCM TTL: auto-set to 0 for critical (instant delivery, no FCM caching)
+        if push_data["critical_ttl"] is not None:
+            data["ttl"] = push_data["critical_ttl"]
+        elif priority == const.PRIORITY_CRITICAL:
+            data["ttl"] = ANDROID_CRITICAL_TTL
+
+        # FCM priority override
+        if push_data["critical_android_priority"] is not None:
+            data["priority"] = push_data["critical_android_priority"]
+
+        # Android TTS: read message aloud on device (Android 8+)
+        if push_data["tts_text"]:
+            data["tts_text"] = push_data["tts_text"]
+            if push_data["tts_locale"]:
+                data["tts_text_language"] = push_data["tts_locale"]
+            if push_data["tts_engine"]:
+                data["tts_engine"] = push_data["tts_engine"]
+
+        # Notification Commands (Android 8+)
+        if push_data["command_screen_on"]:
+            data["command_screen_on"] = True
+        if push_data["command_dnd"]:
+            data["command_dnd"] = push_data["command_dnd"]
+        if push_data["command_ringer_mode"]:
+            data["command_ringer_mode"] = push_data["command_ringer_mode"]
 
     async def action_title(self, url: str, retry_timeout: int = 900) -> str | None:
         """Attempt to create a title for mobile action from the TITLE of the web page at the URL"""
@@ -118,54 +245,71 @@ class MobilePushTransport(Transport):
         if not envelope.target.mobile_app_ids:
             _LOGGER.warning("SUPERNOTIFY No targets provided for mobile_push")
             return False
-        data: dict[str, Any] = dict(envelope.data) if envelope.data else {}
-        category = data.get(ATTR_ACTION_CATEGORY, "general")
-        action_groups = envelope.action_groups
 
+        # 1. Extract SuperNotify push_* keys; raw_data becomes passthrough-only
+        raw_data: dict[str, Any] = dict(envelope.data) if envelope.data else {}
+        push_data = self._extract_push_data(raw_data)
+
+        action_groups = envelope.action_groups
         _LOGGER.debug("SUPERNOTIFY notify_mobile: %s -> %s", envelope.title, envelope.target.mobile_app_ids)
 
-        media = envelope.media or {}
-        camera_entity_id = media.get(ATTR_MEDIA_CAMERA_ENTITY_ID)
-        clip_url: str | None = self.hass_api.abs_url(media.get(ATTR_MEDIA_CLIP_URL))
-        snapshot_url: str | None = self.hass_api.abs_url(media.get(ATTR_MEDIA_SNAPSHOT_URL))
-        # options = data.get(CONF_OPTIONS, {})
+        # 2. Build iOS interruption_level
+        ios_level = push_data["critical_level_ios"] or IOS_INTERRUPTION_MAP.get(
+            envelope.priority or const.PRIORITY_MEDIUM, "active"
+        )
 
-        match envelope.priority:
-            case const.PRIORITY_CRITICAL:
-                push_priority = "critical"
-            case const.PRIORITY_HIGH:
-                push_priority = "time-sensitive"
-            case const.PRIORITY_MEDIUM:
-                push_priority = "active"
-            case const.PRIORITY_LOW:
-                push_priority = "passive"
-            case const.PRIORITY_MINIMUM:
-                push_priority = "passive"
-            case _:
-                push_priority = "active"
-                _LOGGER.warning("SUPERNOTIFY Unexpected priority %s", envelope.priority)
-
-        data.setdefault("actions", [])
+        # 3. Start with passthrough data, then layer SuperNotify fields
+        data: dict[str, Any] = dict(raw_data)
+        category = data.get(ATTR_ACTION_CATEGORY, "general")
         data.setdefault("push", {})
-        data["push"]["interruption-level"] = push_priority
-        if push_priority == "critical":
+        data["push"]["interruption-level"] = ios_level
+
+        if ios_level == "critical":
             data["push"].setdefault("sound", {})
             data["push"]["sound"].setdefault("name", ATTR_DEFAULT)
             data["push"]["sound"]["critical"] = 1
             data["push"]["sound"].setdefault("volume", 1.0)
+            # critical notifications cannot be grouped on iOS
         else:
-            # critical notifications can't be grouped on iOS
-            category = category or camera_entity_id or "appd"
-            data.setdefault("group", category)
+            media = envelope.media or {}
+            camera_entity_id_for_group = media.get(ATTR_MEDIA_CAMERA_ENTITY_ID)
+            data.setdefault("group", category or camera_entity_id_for_group or "appd")
+
+        # 4. iOS extra fields
+        if push_data["subtitle"]:
+            data["subtitle"] = push_data["subtitle"]
+
+        # 5. Android-specific fields
+        self._apply_android_payload(data, push_data, envelope.priority)
+
+        # 6. Cross-platform: notification tag
+        notification_tag = push_data["notification_tag"]
+        if notification_tag:
+            data["tag"] = notification_tag
+        elif push_data["clear_notification"]:
+            _LOGGER.warning(
+                "SUPERNOTIFY mobile_push: push_clear_notification=True requires push_notification_tag to be set — ignoring"
+            )
+
+        # 7. Media: camera entity (grab processed image) + fallback URLs
+        media = envelope.media or {}
+        camera_entity_id = media.get(ATTR_MEDIA_CAMERA_ENTITY_ID)
+        clip_url: str | None = self.hass_api.abs_url(media.get(ATTR_MEDIA_CLIP_URL))
+        snapshot_url: str | None = self.hass_api.abs_url(media.get(ATTR_MEDIA_SNAPSHOT_URL))
 
         if camera_entity_id:
             data["entity_id"] = camera_entity_id
-            # data['actions'].append({'action':'URI','title':'View Live','uri':'/cameras/%s' % device}
+            # Retrieve processed camera image via grab_image() pipeline (v1.14.0+)
+            image_path = await grab_image(envelope.notification, envelope.delivery, self.context)
+            if image_path:
+                data["image"] = str(image_path)
         if clip_url:
             data["video"] = clip_url
-        if snapshot_url:
+        if snapshot_url and "image" not in data:
+            # Fallback: use pre-computed snapshot URL if grab_image() produced nothing
             data["image"] = snapshot_url
 
+        # 8. Actions: URL-title fetching, snooze action, action groups (unchanged)
         data.setdefault("actions", [])
         for action in envelope.actions:
             app_url: str | None = self.hass_api.abs_url(action.get(ATTR_ACTION_URL))
@@ -186,12 +330,28 @@ class MobilePushTransport(Transport):
                 data["actions"].extend(actions)
         if not data["actions"]:
             del data["actions"]
+
+        # 9. Dispatch to each mobile target
         action_data = envelope.core_action_data()
         action_data[ATTR_DATA] = data
+        clear_notification = bool(push_data["clear_notification"] and notification_tag)
         hits = 0
         for mobile_target in envelope.target.mobile_app_ids:
             full_target = mobile_target if Target.is_notify_entity(mobile_target) else f"notify.{mobile_target}"
-            if await self.call_action(envelope, qualified_action=full_target, action_data=action_data, implied_target=True):
+
+            if clear_notification:
+                # Override message to "clear_notification" to dismiss same-tag notification on device
+                clear_action_data = dict(action_data)
+                clear_action_data["message"] = "clear_notification"
+                success = await self.call_action(
+                    envelope, qualified_action=full_target, action_data=clear_action_data, implied_target=True
+                )
+            else:
+                success = await self.call_action(
+                    envelope, qualified_action=full_target, action_data=action_data, implied_target=True
+                )
+
+            if success:
                 hits += 1
             else:
                 simple_target = (
@@ -199,7 +359,7 @@ class MobilePushTransport(Transport):
                 )
                 _LOGGER.warning("SUPERNOTIFY Failed to send to %s, snoozing for a day", simple_target)
                 if self.people_registry:
-                    # somewhat hacky way to tie the mobile device back to a recipient to please the snoozing api
+                    # tie the mobile device back to a recipient for the snoozing API
                     for recipient in self.people_registry.enabled_recipients():
                         for md in recipient.mobile_devices:
                             if md in (simple_target, mobile_target):


### PR DESCRIPTION

## Summary

Enhances the existing `mobile_push` transport with two bug fixes and nine new optional
data keys that expose native Companion App features not previously accessible via SuperNotify.
All changes are 100% backward compatible — existing configurations require no changes.

## Bug Fixes

### Fix 1: Missing `SNAPSHOT_IMAGE` in `supported_features`

**Symptom:** In v1.14.0, `mobile_push` was incorrectly categorized as an "immediate" delivery
by `notification.py`. When a PTZ camera was involved, `mobile_push` could execute *before*
the camera had panned to its target position, resulting in a missing or stale image.

**Root cause:** `supported_features` lacked `TransportFeature.SNAPSHOT_IMAGE`, so
`notification.py` did not defer it to the "wait for PTZ" group.

**Fix:** Added `TransportFeature.SNAPSHOT_IMAGE` to `supported_features`.

### Fix 2: Camera entity not using `grab_image()` pipeline

**Symptom:** When `camera_entity_id` was provided in `envelope.media`, `mobile_push`
only set `data["entity_id"]` on the payload but never retrieved the actual processed image.
The image in the push notification was a live camera tile (entity view), not a snapshot.

**Root cause:** The transport never called `grab_image()` from `media_grab.py`.

**Fix:** Added `grab_image()` call after setting `entity_id`. The processed image
(resized, JPEG-optimized, metadata stripped) is now attached as `data["image"]`.
Falls back to `snapshot_url` if `grab_image()` returns None.

## New Features

All new features use optional `push_*` data keys in `envelope.data`. No existing keys
are required or modified.

### Critical Notifications

| Key | Platform | Description |
|-----|----------|-------------|
| `push_critical_level_ios` | iOS 15+ | Override `interruption_level` (`passive`/`active`/`time-sensitive`/`critical`). Auto-mapped from SuperNotify priority if omitted. |
| `push_critical_ttl` | Android | FCM Time-To-Live in ms. Auto-set to `0` (instant delivery) for `priority=critical` if not specified. |
| `push_critical_android_priority` | Android | FCM delivery priority (1=min, 5=max). |
| `push_channel_override` | Android 8+ | Notification channel (e.g. `alarm`, `general`). |
| `push_alarm_stream` | Android | Route audio through alarm stream — interrupts DND and silent mode. |
| `push_alarm_stream_max` | Android | Alarm stream at maximum device volume. |

### Notification Tag (replacement/grouping)

| Key | Platform | Description |
|-----|----------|-------------|
| `push_notification_tag` | iOS + Android | Tag for notification replacement (iOS) or grouping (Android). |
| `push_clear_notification` | iOS + Android | Send `clear_notification` to dismiss the previous notification with the same tag. Requires `push_notification_tag`. |

### iOS Enhancements

| Key | Platform | Description |
|-----|----------|-------------|
| `push_subtitle` | iOS 10+ | Subtitle line between title and message body. |

### Android Text-To-Speech

| Key | Platform | Description |
|-----|----------|-------------|
| `push_tts_text` | Android 8+ | Text read aloud on device via TTS engine. |
| `push_tts_locale` | Android 8+ | BCP-47 locale (e.g. `it-IT`, `en-US`). Used only when `push_tts_text` is set. |
| `push_tts_engine` | Android 8+ | TTS engine package (e.g. `com.google.android.tts`). Defaults to system TTS if omitted. |

### Android Notification Commands

| Key | Platform | Description |
|-----|----------|-------------|
| `push_command_screen_on` | Android 8+ | Turn on device screen when notification is delivered. |
| `push_command_dnd` | Android 8+ | Change Do Not Disturb: `"toggle"`, `"off"`, or `"on"`. |
| `push_command_ringer_mode` | Android 8+ | Change ringer: `"silent"`, `"vibrate"`, or `"normal"`. |

## Architecture Changes

- Added `_extract_push_data()` private method — extracts all `push_*` keys from `envelope.data`
  via `pop()` before the dict is used as passthrough to the Companion App. This ensures no
  SuperNotify-internal keys leak into the service call (per project convention).
- Added `_apply_android_payload()` private method — applies all Android-specific flat fields
  to the data dict. Separation of concerns facilitates unit testing.
- `IOS_INTERRUPTION_MAP` and `ANDROID_CRITICAL_TTL` defined as module-level constants.

## Backward Compatibility

Fully backward compatible. The only behavioral changes for existing configurations are:

1. `priority=critical` now auto-sets `ttl=0` on Android (was previously unset). This is
   an improvement: critical notifications are now delivered instantly without FCM buffering.
2. Camera entity snapshots now use `grab_image()`, providing optimized images (resize,
   JPEG compression, metadata removal) instead of raw camera entity tiles.

## Testing

41 unit tests added in `tests/components/supernotify/transports/test_mobile_push.py`:

- 6 `supported_features` flag tests
- 8 priority mapping tests (critical/high/medium/low/minimum + override + iOS sound + Android TTL)
- 3 iOS feature tests (subtitle, level override, key extraction)
- 11 Android feature tests (TTS, commands, channel, alarm stream, TTL, priority)
- 3 tag/clear tests (tag added, clear with tag, clear without tag → warning)
- 3 camera/image tests (grab_image called, path attached, snapshot_url fallback)
- 3 passthrough tests (generic keys preserved, None data, empty data)
- 4 edge case tests (no targets, multiple targets, partial failure, all failure)

All 41 tests pass.

## Example Configuration

```yaml
# Critical alarm that bypasses DND on both platforms
deliveries:
  - name: mobile_critical
    transport: mobile_push
    priority: critical
    data:
      push_critical_level_ios: critical    # iOS: bypass DND
      push_critical_ttl: 0               # Android: instant FCM delivery
      push_alarm_stream: true            # Android: alarm audio stream
      push_command_screen_on: true       # Android: wake screen

# Tag-based notification update (replaces previous on iOS)
  - name: mobile_sensor_update
    transport: mobile_push
    data:
      push_notification_tag: temp_kitchen
      push_subtitle: "Sensore cucina"

# Android TTS voice alert
  - name: mobile_voice
    transport: mobile_push
    data:
      push_tts_text: "La porta del garage è aperta da 10 minuti."
      push_tts_locale: it-IT
```

## Files Changed

- `custom_components/supernotify/transports/mobile_push.py` — main changes
- `tests/components/supernotify/transports/test_mobile_push.py` — new file

## Related

- Fixes behavior introduced in v1.14.0 (asyncio.gather parallelization and SNAPSHOT_IMAGE flag)
- Companion App documentation: https://companion.home-assistant.io/docs/notifications/notifications-basic
