### PR TITLE
fix(test): patch envelope.grab_image() to unbreak main CI

### DIFF
--- a/tests/components/supernotify/transports/test_transport_pushover.py
+++ b/tests/components/supernotify/transports/test_transport_pushover.py
@@ -152,7 +152,7 @@ async def test_priority_mapping(sn_priority: str, expected_pushover_priority: in
 
     # For critical, patch grab_image and the service call to avoid emergency-mode loop
     with patch(
-        "custom_components.supernotify.transports.pushover.grab_image",
+        "custom_components.supernotify.envelope.Envelope.grab_image",
         new=AsyncMock(return_value=None),
     ):
         e = _envelope(ctx, priority=sn_priority)
@@ -214,7 +214,7 @@ async def test_emergency_auto_retry_expire() -> None:
     uut = ctx.transport(TRANSPORT_PUSHOVER)
 
     with patch(
-        "custom_components.supernotify.transports.pushover.grab_image",
+        "custom_components.supernotify.envelope.Envelope.grab_image",
         new=AsyncMock(return_value=None),
     ):
         e = _envelope(ctx, priority=PRIORITY_CRITICAL)
@@ -233,7 +233,7 @@ async def test_emergency_explicit_retry_expire() -> None:
     uut = ctx.transport(TRANSPORT_PUSHOVER)
 
     with patch(
-        "custom_components.supernotify.transports.pushover.grab_image",
+        "custom_components.supernotify.envelope.Envelope.grab_image",
         new=AsyncMock(return_value=None),
     ):
         e = _envelope(
@@ -255,7 +255,7 @@ async def test_emergency_retry_clamped_to_minimum() -> None:
     uut = ctx.transport(TRANSPORT_PUSHOVER)
 
     with patch(
-        "custom_components.supernotify.transports.pushover.grab_image",
+        "custom_components.supernotify.envelope.Envelope.grab_image",
         new=AsyncMock(return_value=None),
     ):
         e = _envelope(
@@ -275,7 +275,7 @@ async def test_emergency_expire_clamped_to_maximum() -> None:
     uut = ctx.transport(TRANSPORT_PUSHOVER)
 
     with patch(
-        "custom_components.supernotify.transports.pushover.grab_image",
+        "custom_components.supernotify.envelope.Envelope.grab_image",
         new=AsyncMock(return_value=None),
     ):
         e = _envelope(
@@ -295,7 +295,7 @@ async def test_emergency_callback_included() -> None:
     uut = ctx.transport(TRANSPORT_PUSHOVER)
 
     with patch(
-        "custom_components.supernotify.transports.pushover.grab_image",
+        "custom_components.supernotify.envelope.Envelope.grab_image",
         new=AsyncMock(return_value=None),
     ):
         e = _envelope(
@@ -479,7 +479,7 @@ async def test_attach_image_calls_grab_image() -> None:
     mock_path.__str__.return_value = "/config/www/supernotify_pushover_snap.jpg"
 
     with patch(
-        "custom_components.supernotify.transports.pushover.grab_image",
+        "custom_components.supernotify.envelope.Envelope.grab_image",
         new=AsyncMock(return_value=mock_path),
     ) as mock_grab:
         e = _envelope(ctx, data={"pushover_attach_image": True})
@@ -497,7 +497,7 @@ async def test_attach_image_grab_returns_none_no_attachment() -> None:
     uut = ctx.transport(TRANSPORT_PUSHOVER)
 
     with patch(
-        "custom_components.supernotify.transports.pushover.grab_image",
+        "custom_components.supernotify.envelope.Envelope.grab_image",
         new=AsyncMock(return_value=None),
     ):
         e = _envelope(ctx, data={"pushover_attach_image": True})
@@ -513,7 +513,7 @@ async def test_attach_image_false_no_grab_call() -> None:
     uut = ctx.transport(TRANSPORT_PUSHOVER)
 
     with patch(
-        "custom_components.supernotify.transports.pushover.grab_image",
+        "custom_components.supernotify.envelope.Envelope.grab_image",
         new=AsyncMock(return_value=None),
     ) as mock_grab:
         e = _envelope(ctx, data={"pushover_attach_image": False})
@@ -531,7 +531,7 @@ async def test_attach_image_grab_exception_delivery_continues() -> None:
     uut = ctx.transport(TRANSPORT_PUSHOVER)
 
     with patch(
-        "custom_components.supernotify.transports.pushover.grab_image",
+        "custom_components.supernotify.envelope.Envelope.grab_image",
         new=AsyncMock(side_effect=Exception("camera unreachable")),
     ):
         e = _envelope(ctx, data={"pushover_attach_image": True})
@@ -548,7 +548,7 @@ async def test_attach_image_string_yaml_true() -> None:
     uut = ctx.transport(TRANSPORT_PUSHOVER)
 
     with patch(
-        "custom_components.supernotify.transports.pushover.grab_image",
+        "custom_components.supernotify.envelope.Envelope.grab_image",
         new=AsyncMock(return_value=None),
     ) as mock_grab:
         e = _envelope(ctx, data={"pushover_attach_image": "true"})


### PR DESCRIPTION
## Bug

After #92 merged into main, `test_transport_pushover.py` immediately
broke because the tests patch the `grab_image` symbol on the pushover
module:

```python
with patch(
    "custom_components.supernotify.transports.pushover.grab_image",
    new=AsyncMock(return_value=None),
):
```

But the transport switched to calling `envelope.grab_image()` (the
`Envelope` helper) and the module-level import was dropped. The patch
target therefore raises:

```
AttributeError: module 'custom_components.supernotify.transports.pushover'
                does not have the attribute 'grab_image'
```

11 tests in that file fail. Because every other PR branches from main,
the failure cascades: #93 LaMetric and #95 Telegram both show the same 11
red tests in `test (3.13)` and `test (3.14)` even though they touch
unrelated files.

## Fix

Patch `custom_components.supernotify.envelope.Envelope.grab_image`
instead — that is where the actual logic lives, so it is the more
accurate mock target as well.

No production code changed. 11 patch targets updated, nothing else
modified.

## Verification

- `ruff check tests/components/supernotify/transports/test_transport_pushover.py`: clean
- `codespell tests/components/supernotify/transports/test_transport_pushover.py`: clean
- Ran the file locally: 11 previously-red tests now pass, the rest unchanged

Once this lands, #93 and #95 will need a rebase/merge from main to inherit
the fix and clear their CI.

## Side note

I noticed two related issues while debugging this — both deserve their
own threads but mentioning here for awareness:

1. The same `grab_image` retrieval pattern that sneaks into mocked tests
   without breaking anything until the production code drops the module
   import is a footgun. Possibly worth a CI guard or a docstring note on
   `Envelope.grab_image()` recommending it as the canonical patch target
   for transport tests.
2. Several transports still cache a module-level `grab_image` import
   even though they no longer use it (legacy from pre-v1.14.0). I have
   not changed any of them in this PR — happy to send a cleanup PR if
   you want.