### PR TITLE
fix(test): import Envelope from envelope module to unbreak CI

### DIFF
--- a/tests/components/supernotify/transports/test_transport_telegram.py
+++ b/tests/components/supernotify/transports/test_transport_telegram.py
@@ -23,10 +23,8 @@ from custom_components.supernotify.const import (
     PRIORITY_MEDIUM,
     PRIORITY_MINIMUM,
 )
-from custom_components.supernotify.model import (
-    Envelope,
-    TransportFeature,
-)
+from custom_components.supernotify.envelope import Envelope
+from custom_components.supernotify.model import TransportFeature
 
 # Relative imports from the supernotify codebase
 from custom_components.supernotify.transports.telegram import TelegramTransport


### PR DESCRIPTION
After the cascade merge of PRs #92, #93, #95 and #97, CI on main is failing on every push because `test_transport_telegram.py` imports `Envelope` from `custom_components.supernotify.model`, but `Envelope` lives in `custom_components.supernotify.envelope`.

### Failure

Test (3.14):
Same error on test (3.13). The whole `test_transport_telegram` collection fails, blocking deploy and any subsequent merges.

### Root cause

Lines 24-27 of the test file:

```python
from custom_components.supernotify.model import (
    Envelope,
    TransportFeature,
)
```

`Envelope` was never exported by `model.py` (it has its own module). The PR #95 branch ran green in isolation because the conftest setup masked the error path, but on `main` the collection fails outright.

### Fix

Split the import:

```python
from custom_components.supernotify.envelope import Envelope
from custom_components.supernotify.model import TransportFeature
```

One-line, no behaviour change, restores CI to green.