### PR TITLE
fix(alexa): wait_for_tts without auto pause, audio state restore, and camera_delay schema default

### DIFF
--- a/custom_components/supernotify/schema.py
+++ b/custom_components/supernotify/schema.py
@@ -392,7 +392,10 @@ CAMERA_SCHEMA = vol.Schema({
 })
 MEDIA_SCHEMA = vol.Schema({
     vol.Optional(ATTR_MEDIA_CAMERA_ENTITY_ID): cv.entity_id,
-    vol.Optional(ATTR_MEDIA_CAMERA_DELAY, default=0): int,
+    # No default: media_grab tells "not asked for" from an explicit 0, and a default here
+    # silently overrides the camera's own ptz_delay for any media block that goes through
+    # this schema, such as the ones declared in a scenario.
+    vol.Optional(ATTR_MEDIA_CAMERA_DELAY): int,
     vol.Optional(ATTR_MEDIA_CAMERA_PTZ_PRESET): vol.Any(cv.positive_int, cv.string),
     # URL fragments allowed
     vol.Optional(ATTR_MEDIA_CLIP_URL): vol.Any(cv.url, cv.string),

--- a/custom_components/supernotify/transports/alexa_media_player.py
+++ b/custom_components/supernotify/transports/alexa_media_player.py
@@ -316,9 +316,14 @@ class AlexaMediaPlayerTransport(Transport):
             if requested_volume is not None and states:
                 volume_set_failed = await self._pre_announce(states, requested_volume, pause_music)
             elif pause_music and states:
-                for mp, prev in states.items():
-                    if prev["playing"]:
-                        await self._safe_service("media_player", "media_pause", {ATTR_ENTITY_ID: mp})
+                # Same reasoning as _pre_announce: overlap the per-device cloud round trips.
+                await asyncio.gather(
+                    *(
+                        self._safe_service("media_player", "media_pause", {ATTR_ENTITY_ID: mp})
+                        for mp, prev in states.items()
+                        if prev["playing"]
+                    )
+                )
 
         # Announce
         call_type: str = raw_data.pop("type", "announce")
@@ -334,24 +339,26 @@ class AlexaMediaPlayerTransport(Transport):
 
         result = await self.call_action(envelope, action_data=action_data)
 
-        if auto_pause:
-            # Post-announce: optionally wait for TTS, then restore volume / resume music.
-            # needs_post_announce is True whenever there is something to undo (volume change
-            # or music was paused); in that case the TTS wait is always performed so the
-            # restore/resume happens after Alexa finishes speaking.
-            # wait_for_tts additionally blocks even in pure fire-and-forget deliveries,
-            # allowing automation sequences to run only after the announcement ends.
-            needs_post_announce = needs_restore and bool(states)
-            if (needs_post_announce or wait_for_tts) and envelope.message:
-                tts_duration = _estimate_tts_duration(envelope.message, tts_char_speed)
-                _LOGGER.debug(
-                    "SUPERNOTIFY alexa_media_player: waiting %.1f s for TTS (%d chars, %.3f s/ch)",
-                    tts_duration,
-                    len(RE_SSML_TAG.sub("", envelope.message)),
-                    tts_char_speed,
-                )
-                await asyncio.sleep(tts_duration)
-                if needs_post_announce:
-                    await self._post_announce(states, restore_volume and requested_volume is not None, pause_music)
+        # Post-announce: optionally wait for TTS, then restore volume / resume music.
+        # needs_post_announce is True whenever there is something to undo (volume change
+        # or music was paused); in that case the TTS wait is always performed so the
+        # restore/resume happens after Alexa finishes speaking.
+        # wait_for_tts additionally blocks even in pure fire-and-forget deliveries,
+        # allowing automation sequences to run only after the announcement ends, so it is
+        # honoured independently of `media_auto_pause`.
+        needs_post_announce = auto_pause and needs_restore and bool(states)
+        if (needs_post_announce or wait_for_tts) and envelope.message:
+            tts_duration = _estimate_tts_duration(envelope.message, tts_char_speed)
+            _LOGGER.debug(
+                "SUPERNOTIFY alexa_media_player: waiting %.1f s for TTS (%d chars, %.3f s/ch)",
+                tts_duration,
+                len(RE_SSML_TAG.sub("", envelope.message)),
+                tts_char_speed,
+            )
+            await asyncio.sleep(tts_duration)
+        if needs_post_announce:
+            # Restore even for an empty message: the pre-announce already paused the device
+            # and changed its volume, so skipping this would leave it that way indefinitely.
+            await self._post_announce(states, restore_volume and requested_volume is not None, pause_music)
 
         return result

--- a/tests/components/supernotify/test_media_grab.py
+++ b/tests/components/supernotify/test_media_grab.py
@@ -683,6 +683,27 @@ async def test_grab_image_with_camera_no_ptz_skips_delay(hass: HomeAssistant, tm
     mock_sleep.assert_not_called()
 
 
+async def test_grab_image_from_scenario_media_keeps_camera_ptz_delay(hass: HomeAssistant, tmp_aiopath: Path) -> None:
+    """A scenario's `media:` block goes through MEDIA_SCHEMA before reaching the notification.
+    The schema must not fill in a camera_delay, or it would silently override the camera's own
+    ptz_delay, which is only reached when no delay was asked for."""
+    from custom_components.supernotify.schema import SCENARIO_SCHEMA
+
+    scenario = SCENARIO_SCHEMA({
+        "media": {"camera_entity_id": "camera.front", "camera_ptz_preset": "Doorway"},
+    })
+    ctx = TestingContext(homeassistant=hass, deliveries=DELIVERIES)
+    await ctx.test_initialize()
+    ctx.cameras = {"camera.front": {CONF_CAMERA: "camera.front", CONF_PTZ_DELAY: 3}}
+    with patch("custom_components.supernotify.media_grab.select_avail_camera", return_value="camera.front"):
+        with patch("custom_components.supernotify.media_grab.snap_camera", return_value=None):
+            with patch("custom_components.supernotify.media_grab.move_camera_to_ptz_preset", new_callable=AsyncMock):
+                with patch("custom_components.supernotify.media_grab.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+                    notification = Notification(ctx, "Test", action_data={"media": scenario["media"]})
+                    await snap_notification_image(notification, ctx)
+    mock_sleep.assert_called_once_with(3)
+
+
 async def test_grab_image_with_camera_ptz_applies_delay(hass: HomeAssistant, tmp_aiopath: Path) -> None:
     """The ptz_delay wait should still be applied after an actual PTZ move."""
     ctx = TestingContext(homeassistant=hass, deliveries=DELIVERIES)

--- a/tests/components/supernotify/transports/test_alexa_media_player.py
+++ b/tests/components/supernotify/transports/test_alexa_media_player.py
@@ -234,6 +234,7 @@ class TestPostAnnounce:
         ) as mock_sleep:
             await t._post_announce(states, restore_volume=True, pause_music=True)
             mock_sleep.assert_not_awaited()
+        assert "media_play" not in _service_names(t)
 
     @pytest.mark.asyncio
     async def test_runs_volume_restore_concurrently(self):
@@ -436,3 +437,58 @@ class TestDeliver:
         names = _service_names(t)
         assert "media_pause" not in names
         assert "volume_set" not in names
+
+    @pytest.mark.asyncio
+    async def test_wait_for_tts_honoured_with_auto_pause_disabled(self):
+        """wait_for_tts sequences automation steps after the announcement and is independent of
+        the pause/restore handling, so disabling auto pause must not silently disable it."""
+        t = _make_transport({"media_player.sala": {"state": "idle", "volume_level": 0.5}})
+        envelope = _make_envelope(
+            "Test message",
+            data={"wait_for_tts": True},
+            entity_ids=["media_player.sala"],
+            delivery_options={"media_auto_pause": False},
+        )
+        with patch(
+            "custom_components.supernotify.transports.alexa_media_player.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep:
+            await t.deliver(envelope)
+        mock_sleep.assert_awaited_once()
+        names = _service_names(t)
+        assert "media_pause" not in names
+        assert "volume_set" not in names
+
+    @pytest.mark.asyncio
+    async def test_restore_runs_even_for_empty_message(self):
+        """An empty message still goes through the pre-announce, so the restore must run too,
+        otherwise the device is left paused at announcement volume indefinitely."""
+        t = _make_transport({"media_player.sala": {"state": "playing", "volume_level": 0.4}})
+        envelope = _make_envelope("", data={"volume": 0.9}, entity_ids=["media_player.sala"])
+        with patch("custom_components.supernotify.transports.alexa_media_player.asyncio.sleep", new_callable=AsyncMock):
+            await t.deliver(envelope)
+        names = _service_names(t)
+        assert "media_pause" in names
+        assert "media_play" in names, "music was paused but never resumed"
+
+    @pytest.mark.asyncio
+    async def test_pause_only_path_runs_concurrently(self):
+        """The pause-only path (no volume requested) is the common case for plain announcements
+        and must overlap the per-device cloud calls, like the volume path already does."""
+        t = _make_transport({f"media_player.d{i}": {"state": "playing", "volume_level": 0.5} for i in range(5)})
+        envelope = _make_envelope("Test", data={}, entity_ids=[f"media_player.d{i}" for i in range(5)])
+        call_delay = 0.2
+        # captured before the patch below, which replaces asyncio.sleep module-wide
+        real_sleep = asyncio.sleep
+
+        async def _delayed_call(*args, **kwargs):
+            await real_sleep(call_delay)
+
+        t.hass_api.call_service = AsyncMock(side_effect=_delayed_call)
+        with patch("custom_components.supernotify.transports.alexa_media_player.asyncio.sleep", new_callable=AsyncMock):
+            start = time.perf_counter()
+            await t.deliver(envelope)
+            elapsed = time.perf_counter() - start
+        pause_calls = [c for c in t.hass_api.call_service.call_args_list if c.args[1] == "media_pause"]
+        assert len(pause_calls) == 5
+        # concurrent: one pause round plus one resume round; sequential would be five of each
+        assert elapsed < call_delay * 4


### PR DESCRIPTION
Follow-up to #176, on top of v2.2.2. Four fixes, each with a regression test that fails on the tag.

### `wait_for_tts` ignored without auto pause (the other half of #176)

The post-announce block, `wait_for_tts` included, was still inside `if auto_pause:`, so a delivery with `media_auto_pause: false` and `wait_for_tts: true` never waited — while the docs describe the key as blocking "even when no volume/music restore is needed". The block moves out of the guard; `needs_post_announce` now carries `auto_pause` explicitly, so the pause/restore handling stays disabled exactly as before.

### Audio state never restored for an empty message

The restore was nested under `and envelope.message`, but the pre-announce runs regardless of the message: an empty message left the device paused and at announcement volume with nothing to undo it. The TTS wait still only happens when there is something to say.

### Pause-only path left sequential

2.2.1 made `_pre_announce`/`_post_announce` concurrent, but the `elif pause_music and states:` branch — the path taken by a plain announcement with no explicit `volume`, i.e. the common one — stayed a per-device `for`. Now uses `asyncio.gather` like its sibling.

### `MEDIA_SCHEMA` defaulted `camera_delay` to 0

`vol.Optional(ATTR_MEDIA_CAMERA_DELAY, default=0)` makes "not asked for" indistinguishable from an explicit zero. Any media block validated by the schema — a scenario's `media:` section, for one — therefore reaches `snap_notification_image` with `camera_delay: 0`, `int_or_none` returns 0 rather than `None`, and the camera's `ptz_delay` (and `PTZ_DELAY_DEFAULT`) is skipped: the snapshot fires immediately after the PTZ move. Removing the default restores the distinction the 2.2.2 fix relies on.

### Also here

- Restores `assert "media_play" not in _service_names(t)` in `test_no_resume_when_was_not_playing`; the line moved into `test_runs_volume_restore_concurrently` in the 2.2.1 diff, leaving the first test without its final check.

### Verification

Python 3.13, same checks as CI: 1138 tests pass, `ruff check custom_components tests` clean, `ruff format --check` clean, `mypy custom_components/supernotify` clean. The four new tests each fail on v2.2.2 and pass here.

One note for whoever writes the next concurrency test: patching `custom_components.supernotify.transports.alexa_media_player.asyncio.sleep` replaces the attribute on the shared `asyncio` module, so it also neutralises any `asyncio.sleep` the test itself uses to simulate call latency — the timing assertion then passes no matter what. `test_pause_only_path_runs_concurrently` captures `real_sleep = asyncio.sleep` before patching for that reason.
