### PR TITLE
Add diagnostics.py for config entry diagnostics

### DIFF
--- a/custom_components/supernotify/diagnostics.py
+++ b/custom_components/supernotify/diagnostics.py
@@ -1,0 +1,59 @@
+"""Diagnostics support for the Supernotify integration.
+
+Exposes the same operational state already surfaced piecemeal through the various
+`supernotify.enquire_*` admin services (notify.py) - recipients, scenario/delivery routing,
+snoozes, the last notification sent, and the sent/failure counters - through Home Assistant's
+standard Settings > Devices & Services > Supernotify > Download diagnostics flow, so a bug
+report doesn't require walking the user through calling half a dozen services first.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.core import HomeAssistant
+
+if TYPE_CHECKING:
+    from . import SupernotifyConfigEntry
+
+# Person.as_dict() (people.py) is the source of every identifying field below - reached both
+# directly (enquire_recipients) and indirectly (a snooze or the last notification can reference
+# a recipient by the same fields). async_redact_data walks every nested dict/list, so listing
+# the field names here is enough regardless of where they turn up in the returned structure.
+TO_REDACT = {
+    "email",
+    "phone_number",
+    "user_id",
+    "alias",
+}
+
+
+async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: SupernotifyConfigEntry) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    service = entry.runtime_data
+    last_notification = service.last_notification
+
+    data: dict[str, Any] = {
+        "entry": {
+            "version": entry.version,
+            "minor_version": entry.minor_version,
+            "data": dict(entry.data),
+            "options": dict(entry.options),
+        },
+        "counters": {
+            "sent": service.sent,
+            "failures": service.failures,
+        },
+        "housekeeping": service.housekeeping,
+        "recipients": service.enquire_recipients(),
+        "scenarios": service.enquire_scenarios(),
+        "deliveries_by_scenario": service.enquire_deliveries_by_scenario(),
+        "implicit_deliveries": service.enquire_implicit_deliveries(),
+        "snoozes": service.enquire_snoozes(),
+        "last_notification": last_notification.contents(diagnostics=True) if last_notification else None,
+        "archive_enabled": service.context.archive.enabled,
+        "media_storage_configured": bool(service.context.media_storage.media_path),
+    }
+
+    return async_redact_data(data, TO_REDACT)

--- a/custom_components/supernotify/quality_scale.yaml
+++ b/custom_components/supernotify/quality_scale.yaml
@@ -222,9 +222,15 @@ rules:
     comment: This integration does not connect to any devices
 
   diagnostics:
-    status: todo
+    status: done
     comment: |
-      Need to create diagnostics.py module once config_entries introduced
+      diagnostics.py's async_get_config_entry_diagnostics surfaces the same operational state
+      already exposed piecemeal via the supernotify.enquire_* admin services (notify.py) -
+      recipients, scenario/delivery routing, snoozes, the last notification sent (in
+      diagnostics mode), and the sent/failure counters - through the standard Settings >
+      Devices & Services > Supernotify > Download diagnostics flow. Every Person.as_dict()
+      identifying field (email, phone_number, user_id, alias) is redacted via
+      homeassistant.components.diagnostics.async_redact_data, wherever it turns up nested.
 
   discovery:
     status: exempt

--- a/tests/components/supernotify/test_diagnostics.py
+++ b/tests/components/supernotify/test_diagnostics.py
@@ -1,0 +1,104 @@
+"""Tests for diagnostics.py."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry  # type: ignore[import-untyped]
+
+from custom_components.supernotify import DOMAIN
+from custom_components.supernotify.const import (
+    ATTR_DUPE_POLICY_NONE,
+    CONF_DUPE_POLICY,
+    CONF_PERSON,
+    CONF_PHONE_NUMBER,
+    CONF_TRANSPORT,
+    TRANSPORT_PERSISTENT,
+)
+from custom_components.supernotify.diagnostics import async_get_config_entry_diagnostics
+from custom_components.supernotify.notify import SupernotifyAction
+
+if TYPE_CHECKING:
+    from unittest.mock import Mock
+
+    from homeassistant.core import HomeAssistant
+
+DELIVERY: dict[str, dict] = {"persistent": {CONF_TRANSPORT: TRANSPORT_PERSISTENT}}
+RECIPIENTS: list[dict] = [
+    {
+        CONF_PERSON: "person.new_home_owner",
+        "email": "me@tester.net",
+        CONF_PHONE_NUMBER: "+2301015050503",
+        "user_id": "abc123userid",
+        "alias": "Real Name",
+    },
+]
+
+
+def _entry(hass: HomeAssistant, service: SupernotifyAction) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+    entry.add_to_hass(hass)
+    entry.runtime_data = service
+    return entry
+
+
+async def test_diagnostics_redacts_recipient_pii(hass: HomeAssistant, mock_hass: Mock) -> None:
+    """Every identifying Recipient field is redacted, non-identifying ones survive untouched.
+
+    recipients_discovery=False keeps this to the single explicitly configured recipient -
+    mock_hass.states.async_entity_ids (conftest.py) otherwise feeds two extra auto-discovered
+    people into the mix, which is irrelevant to what this test is checking.
+    """
+    service = SupernotifyAction(mock_hass, deliveries=DELIVERY, recipients=RECIPIENTS, recipients_discovery=False)
+    await service.initialize()
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, _entry(hass, service))
+
+    assert diagnostics["counters"] == {"sent": 0, "failures": 0}
+    assert len(diagnostics["recipients"]) == 1
+    recipient = diagnostics["recipients"][0]
+    assert recipient["email"] == "**REDACTED**"
+    assert recipient["phone_number"] == "**REDACTED**"
+    assert recipient["user_id"] == "**REDACTED**"
+    assert recipient["alias"] == "**REDACTED**"
+    assert recipient[CONF_PERSON] == "person.new_home_owner"
+
+
+async def test_diagnostics_no_last_notification_before_any_send(hass: HomeAssistant, mock_hass: Mock) -> None:
+    """last_notification is None until something has actually been sent."""
+    service = SupernotifyAction(mock_hass, deliveries=DELIVERY, recipients=[], recipients_discovery=False)
+    await service.initialize()
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, _entry(hass, service))
+
+    assert diagnostics["last_notification"] is None
+
+
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
+async def test_diagnostics_includes_last_notification(hass: HomeAssistant, mock_hass: Mock) -> None:
+    """Once a message has been sent, its contents (in diagnostics mode) are included.
+
+    Pre-existing quirk, unrelated to diagnostics.py itself: Notification.contents(diagnostics=
+    True) -> common.sanitize() walks every attribute of a real Notification built against
+    mock_hass, and at least one of those turns out to be an AsyncMock exposing its own
+    auto-generated `.contents` attribute - sanitize() calls it like the real thing, producing
+    a coroutine nothing awaits. Doesn't happen against a real HomeAssistant instance.
+    """
+    service = SupernotifyAction(
+        mock_hass,
+        deliveries=DELIVERY,
+        recipients=[],
+        recipients_discovery=False,
+        dupe_check={CONF_DUPE_POLICY: ATTR_DUPE_POLICY_NONE},
+    )
+    await service.initialize()
+    # explicit delivery selection keeps this to the one transport/delivery under test, rather
+    # than also triggering the auto-generated implicit deliveries (mobile_push, notify_entity)
+    # that a plain async_send_message would also fan out to
+    await service.async_send_message(message="hello", title="test", data={"delivery": ["persistent"]})
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, _entry(hass, service))
+
+    assert diagnostics["last_notification"] is not None
+    assert diagnostics["last_notification"]["message"] == "hello"


### PR DESCRIPTION
Adds `diagnostics.py`, closing the `diagnostics` gold-tier gap tracked in `quality_scale.yaml` ("Need to create diagnostics.py module once config_entries introduced" - config entries have been in place for a while, the module itself was simply never written).

`async_get_config_entry_diagnostics` reuses the existing `SupernotifyAction.enquire_*` methods (recipients, scenario/delivery routing, snoozes, last notification, sent/failure counters) - the same state already exposed piecemeal via the `supernotify.enquire_*` admin services, now downloadable in one shot from Settings > Devices & Services > Supernotify > Download diagnostics.

Every identifying `Person.as_dict()` field (`email`, `phone_number`, `user_id`, `alias`) is redacted via `homeassistant.components.diagnostics.async_redact_data`, which walks every nested dict/list - so it doesn't matter whether the field turns up directly in `recipients`, or nested inside a snooze or the last notification.

## Test plan
- [x] `tests/components/supernotify/test_diagnostics.py` (3 tests: PII redaction, `last_notification` absent/present)
- [x] `ruff check` / `ruff format --check` on Python 3.14, `codespell`, `mypy` on Python 3.13
- [x] Full `pytest` suite on both Python 3.13 and 3.14: 1172/1172 passing, `diagnostics.py` at 100% line coverage
