### PR TITLE
fix: render Jinja2 templates in delivery data before transport call

### DIFF
--- a/custom_components/supernotify/envelope.py
+++ b/custom_components/supernotify/envelope.py
@@ -113,6 +113,17 @@ class Envelope(DupeCheckable):
         else:
             self.condition_variables = ConditionVariables()
 
+        # Scenario/delivery overrides can express `data` values (e.g. volume,
+        # volume_level, method for alexa_announce) as Jinja2 templates. These
+        # must be resolved once, here, before any transport sees `self.data` -
+        # previously they were only rendered for the archive copy built in
+        # contents(), so the transport call itself received the raw template
+        # string (#64). Keep the pre-render copy so contents() can still show
+        # the raw template alongside the resolved value for debugging.
+        self._raw_data: dict[str, Any] = dict(self.data)
+        if self.context:
+            self.data = self._render_data_templates(self.data)
+
         self.message = self._compute_message()
         self.title = self._compute_title()
 
@@ -174,7 +185,7 @@ class Envelope(DupeCheckable):
                 exclude_attrs.append("target")
 
         json_ready = {k: v for k, v in self.__dict__.items() if k not in exclude_attrs and not k.startswith("_")}
-        json_ready["data"] = self._resolve_data_templates(self.data)
+        json_ready["data"] = self._resolve_data_templates(self._raw_data)
         json_ready["calls"] = [call.contents() for call in self.calls]
         json_ready["failedcalls"] = [call.contents() for call in self.failed_calls]
         return json_ready
@@ -310,6 +321,32 @@ class Envelope(DupeCheckable):
             camera_entity_id,
             media_url,
         ))
+
+    def _render_data_templates(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Render Jinja2 templates in delivery `data` before the transport call.
+
+        Scenario or delivery-level overrides can set `data` values as Jinja2
+        template strings (see `_resolve_data_templates` for the archive/
+        diagnostics equivalent). Unlike that method, this returns a plain
+        resolved dict with no `<key>_template` breadcrumbs, so it is safe to
+        pass straight through to a transport's underlying HA service call.
+        """
+        if not data or not self.context:
+            return data
+        context_vars = cast("dict[str, Any]", self.condition_variables.as_dict()) if self.condition_variables else {}
+        rendered: dict[str, Any] = {}
+        for key, value in data.items():
+            if isinstance(value, str) and "{{" in value:
+                try:
+                    rendered[key] = self.context.hass_api.template(value).async_render(variables=context_vars)
+                except Exception as e:
+                    _LOGGER.warning(
+                        "SUPERNOTIFY Rendering delivery data template for %s.%s failed: %s", self.delivery_name, key, e
+                    )
+                    rendered[key] = value
+            else:
+                rendered[key] = value
+        return rendered
 
     def _resolve_data_templates(self, data: dict[str, Any]) -> dict[str, Any]:
         """Resolve Jinja2 templates in data dict for archive readability.

--- a/tests/components/supernotify/test_envelope.py
+++ b/tests/components/supernotify/test_envelope.py
@@ -243,3 +243,65 @@ async def test_resolve_data_templates_keeps_raw_value_on_render_exception() -> N
         resolved = uut._resolve_data_templates({"greeting": "{{ 1 + 1 }}"})
     assert resolved["greeting"] == "{{ 1 + 1 }}"
     assert "greeting_template" not in resolved
+
+
+async def test_envelope_data_templates_rendered_before_transport() -> None:
+    """Regression test for #64: scenario/delivery `data` templates (e.g. a
+    scenario-driven alexa_announce volume) must be resolved on envelope.data
+    itself - what transports actually read - not only in the archive copy."""
+    context = TestingContext()
+    await context.test_initialize()
+    uut = Envelope(
+        context.delivery("DEFAULT_notify_entity"),
+        Notification(context, message="hello there"),
+        data={"volume": "{{ 1 + 1 }}", "plain": "unchanged"},
+        context=context,
+    )
+    assert uut.data["volume"] == "2"
+    assert uut.data["plain"] == "unchanged"
+    # transport payloads must not be polluted with debug breadcrumbs
+    assert "volume_template" not in uut.data
+
+
+async def test_envelope_data_template_render_exception_keeps_raw_value() -> None:
+    context = TestingContext()
+    await context.test_initialize()
+    with patch.object(context.hass_api, "template", side_effect=Exception("boom")):
+        uut = Envelope(
+            context.delivery("DEFAULT_notify_entity"),
+            Notification(context, message="hello there"),
+            data={"volume": "{{ 1 + 1 }}"},
+            context=context,
+        )
+    assert uut.data["volume"] == "{{ 1 + 1 }}"
+
+
+async def test_envelope_contents_still_shows_raw_template_breadcrumb() -> None:
+    """contents() (archive/diagnostics) should still show the raw template
+    alongside the resolved value, even though envelope.data itself is now
+    pre-resolved for the transport call."""
+    context = TestingContext()
+    await context.test_initialize()
+    uut = Envelope(
+        context.delivery("DEFAULT_notify_entity"),
+        Notification(context, message="hello there"),
+        data={"volume": "{{ 1 + 1 }}"},
+        context=context,
+    )
+    contents = uut.contents(minimal=False)
+    assert contents["data"]["volume"] == "2"
+    assert contents["data"]["volume_template"] == "{{ 1 + 1 }}"
+
+
+async def test_envelope_data_without_context_left_unrendered() -> None:
+    """No template.hass_api context available (no `context=` passed): data is
+    left as-is rather than raising, matching pre-existing behaviour for
+    message/title rendering."""
+    context = TestingContext()
+    await context.test_initialize()
+    uut = Envelope(
+        context.delivery("DEFAULT_notify_entity"),
+        Notification(context, message="hello there"),
+        data={"volume": "{{ 1 + 1 }}"},
+    )
+    assert uut.data["volume"] == "{{ 1 + 1 }}"


### PR DESCRIPTION
## Summary

Fixes #64 — scenario/delivery `data` templates (e.g. a scenario overriding
`alexa_announce.data.volume` with a Jinja2 expression) were never resolved
before the transport call.

`Envelope.data` is the flat dict every transport reads directly
(`raw_data = dict(envelope.data)`). Template rendering already existed
(`_resolve_data_templates()`), but it was only invoked from `contents()` -
i.e. for the archive/diagnostics JSON copy, not for the actual data passed
to the transport. `alexa_media_player.py` already has a local workaround
for the `volume` field only (with a comment pointing at this exact bug),
but no other transport/field (`volume_level`, `method`, etc.) was covered.

## Change

- New `Envelope._render_data_templates()`: same rendering as
  `_resolve_data_templates()`, but returns a plain resolved dict with no
  `<key>_template` debug breadcrumbs, so it's safe to pass straight
  through to a transport's HA service call.
- Called once in `Envelope.__init__`, right after `condition_variables` is
  set (needed as render context), so `self.data` is fully resolved before
  any transport ever sees it.
- Kept a private pre-render copy (`self._raw_data`) so `contents()` still
  shows both the resolved value and the raw `<key>_template` breadcrumb in
  the archive/diagnostics view, exactly as before - only the *source* of
  what's rendered for the transport changed.
- The existing `alexa_media_player.py` volume-template workaround is left
  untouched; it becomes a harmless no-op since `envelope.data["volume"]`
  now arrives already resolved.

## Test plan

- [x] 4 new regression tests in `test_envelope.py` covering: template
      resolved onto `envelope.data`, render-exception keeps raw value,
      `contents()` still shows the `_template` breadcrumb, and no-context
      construction leaves data unrendered (no crash).
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy` clean
- [x] `codespell` clean
- [x] Full test suite green on both supported HA/Python lanes (2026.2.3 /
      py3.13 and 2026.9.1 / py3.14): 1204/1204 passing, coverage gate met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TjY2sf9ZMkGShQktzBNj1o
