### PR TITLE
Silence ty deprecation warning on st_ctime in archive cleanup

### DIFF
--- a/custom_components/supernotify/archive.py
+++ b/custom_components/supernotify/archive.py
@@ -236,7 +236,11 @@ class ArchiveDirectory(ArchiveDestination):
                 for entry in archive:
                     if entry.name == ".startup":
                         continue
-                    if dt_util.utc_from_timestamp(entry.stat().st_ctime) <= cutoff:
+                    # st_ctime is used deliberately here (not st_birthtime): archive files are
+                    # written once and never modified afterwards, so ctime reflects creation time
+                    # on the platforms this integration targets; st_birthtime is not guaranteed to
+                    # be available on all Linux filesystems.
+                    if dt_util.utc_from_timestamp(entry.stat().st_ctime) <= cutoff:  # ty: ignore[deprecated]
                         _LOGGER.debug("SUPERNOTIFY Purging %s", entry.path)
                         await aiofiles.os.unlink(entry.path)
                         purged += 1


### PR DESCRIPTION
`ty` (astral, run by pre-commit.ci) flags the direct access to `os.stat_result.st_ctime` in `archive.py`'s `cleanup()` as deprecated. This is currently the only pre-commit.ci failure on main - noticed because it blocks the `ty` check on every open PR regardless of what that PR touches, since `ty` analyzes whole files, not diffs (seen independently on #180 and #182).

Kept using `st_ctime` deliberately rather than switching to `st_birthtime`: archive files are write-once and never modified afterwards, so ctime reliably reflects creation time here, and `st_birthtime` isn't guaranteed available on every Linux filesystem/Python version this integration supports. Silenced with a scoped `# ty: ignore[deprecated]` plus a comment explaining why.

Verified with `pre-commit run --all-files` (all hooks green) and the full test suite on both supported HA lanes.
