### PR TITLE
Support area, floor and label target selectors

### DIFF
--- a/custom_components/supernotify/const.py
+++ b/custom_components/supernotify/const.py
@@ -198,6 +198,12 @@ OPTION_TARGET_CATEGORIES = "target_categories"
 OPTION_UNIQUE_TARGETS = "unique_targets"
 OPTION_TARGET_INCLUDE_RE = "target_include_re"  # deprecated v1.9.0
 OPTION_TARGET_SELECT = "target_select"
+# how area_id/floor_id/label_id targets are handled for a delivery
+OPTION_TARGET_SELECTORS = "target_selectors"
+TARGET_SELECTORS_AUTO = "auto"  # discover from the action description whether selectors pass through
+TARGET_SELECTORS_NATIVE = "native"  # pass selectors through to the underlying action untouched
+TARGET_SELECTORS_RESOLVE = "resolve"  # resolve selectors to entity_ids within supernotify
+TARGET_SELECTORS_VALUES = [TARGET_SELECTORS_AUTO, TARGET_SELECTORS_NATIVE, TARGET_SELECTORS_RESOLVE]
 OPTION_CHIME_ALIASES = "chime_aliases"
 OPTION_DATA_KEYS_SELECT = "data_keys_select"
 OPTION_DATA_KEYS_INCLUDE_RE = "data_keys_include_re"  # deprecated v1.9.0

--- a/custom_components/supernotify/delivery.py
+++ b/custom_components/supernotify/delivery.py
@@ -50,12 +50,17 @@ from .const import (
     OPTION_TARGET_CATEGORIES,
     OPTION_TARGET_INCLUDE_RE,
     OPTION_TARGET_SELECT,
+    OPTION_TARGET_SELECTORS,
     RESERVED_DELIVERY_NAMES,
     SELECT_EXCLUDE,
     SELECT_INCLUDE,
     SELECTION_DEFAULT,
     SELECTION_FALLBACK,
     SELECTION_FALLBACK_ON_ERROR,
+    TARGET_SELECTORS_AUTO,
+    TARGET_SELECTORS_NATIVE,
+    TARGET_SELECTORS_RESOLVE,
+    TARGET_SELECTORS_VALUES,
 )
 
 if TYPE_CHECKING:
@@ -91,6 +96,9 @@ class Delivery(DeliveryConfig):
             self.target_selector: SelectionRule | None = SelectionRule(self.options.get(OPTION_TARGET_SELECT))
         else:
             self.target_selector = None
+        # whether area_id/floor_id/label_id targets pass through to the action untouched,
+        # decided at initialization by explicit option or discovery from the action description
+        self.passes_target_selectors: bool = False
         self.upgrade_deprecations(conf)
 
     async def initialize(self, context: Context) -> bool:
@@ -135,8 +143,33 @@ class Delivery(DeliveryConfig):
                 errors += 1
 
         self.discover_devices(context)
+        self.passes_target_selectors = self.discover_target_selectors(context)
         self.transport_data = self.transport.setup_delivery_options(self.options, self.name)
         return errors == 0
+
+    def discover_target_selectors(self, context: Context) -> bool:
+        """Decide if HA target selectors (area/floor/label) are passed through to the action, or
+        resolved to entity_ids by supernotify first.
+
+        The `target_selectors` option overrides with `native` or `resolve`; the default `auto` trusts
+        the action description, and falls back to resolving locally when the action is unknown or
+        doesn't declare a `target` block.
+        """
+        mode: str = self.options.get(OPTION_TARGET_SELECTORS, TARGET_SELECTORS_AUTO)
+        if mode == TARGET_SELECTORS_NATIVE:
+            return True
+        if mode == TARGET_SELECTORS_RESOLVE:
+            return False
+        if mode != TARGET_SELECTORS_AUTO:
+            _LOGGER.warning(
+                "SUPERNOTIFY Delivery %s has unknown target_selectors option %s, expected one of %s",
+                self.name,
+                mode,
+                TARGET_SELECTORS_VALUES,
+            )
+        discovered: bool | None = context.hass_api.service_accepts_target_selectors(self.action)
+        _LOGGER.debug("SUPERNOTIFY Delivery %s action %s target selectors discovery: %s", self.name, self.action, discovered)
+        return discovered is True
 
     def upgrade_deprecations(self, conf: ConfigType) -> None:
         # v1.9.0
@@ -193,6 +226,10 @@ class Delivery(DeliveryConfig):
 
     def select_targets(self, target: Target) -> Target:
         def selected(category: str, targets: list[str]) -> list[str]:
+            if category in Target.EXPLICIT_INDIRECT_CATEGORIES:
+                # area/floor/label are either resolved to entity_ids before selection, or passed
+                # through untouched, and never subject to the target_select regex
+                return targets if self.passes_target_selectors else []
             if OPTION_TARGET_CATEGORIES in self.options and category not in self.options[OPTION_TARGET_CATEGORIES]:
                 return []
             if self.target_selector:
@@ -412,6 +449,8 @@ class DeliveryRegistry:
 
     async def initialize_transports(self, context: Context) -> None:
         """Use configure_for_tests() to set transports to mocks or manually created fixtures"""
+        # action descriptions drive discovery of target selector support per delivery
+        await context.hass_api.load_service_descriptions()
         if self._transport_instances:
             for transport in self._transport_instances:
                 self.transports[transport.name] = transport

--- a/custom_components/supernotify/hass_api.py
+++ b/custom_components/supernotify/hass_api.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
 from homeassistant.components.person import ATTR_USER_ID
 from homeassistant.const import (
+    ATTR_AREA_ID,
+    ATTR_FLOOR_ID,
+    ATTR_LABEL_ID,
     CONF_ACTION,
     CONF_DEVICE_ID,
     EntityCategory,
@@ -54,6 +57,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.network import get_url
+from homeassistant.helpers.service import async_get_all_descriptions, async_get_cached_service_description
+from homeassistant.helpers.target import TargetSelection, async_extract_referenced_entity_ids
 from homeassistant.helpers.template import Template
 from homeassistant.helpers.trace import trace_get, trace_path
 from homeassistant.helpers.typing import ConfigType
@@ -117,6 +122,19 @@ class DeviceInfo:
         return other is not None and callable(as_dict) and as_dict() == self.as_dict()
 
 
+@dataclass
+class TargetSelectorResolution:
+    """Outcome of resolving area/floor/label selectors locally"""
+
+    entity_ids: list[str] = field(default_factory=list)
+    missing_areas: list[str] = field(default_factory=list)
+    missing_floors: list[str] = field(default_factory=list)
+    missing_labels: list[str] = field(default_factory=list)
+
+    def has_missing(self) -> bool:
+        return bool(self.missing_areas or self.missing_floors or self.missing_labels)
+
+
 class HomeAssistantAPI:
     def __init__(self, hass: HomeAssistant) -> None:
         self._hass: HomeAssistant = hass
@@ -127,6 +145,7 @@ class HomeAssistantAPI:
         self._entity_registry: er.EntityRegistry | None = None
         self._device_registry: dr.DeviceRegistry | None = None
         self._service_info: dict[tuple[str, str], Any] = {}
+        self._service_descriptions: dict[str, dict[str, Any]] = {}
         self.unsubscribes: list[CALLBACK_TYPE] = []
         self.exposed_entities: list[str] = []
         self.mobile_apps_by_tracker: dict[str, DeviceInfo] = {}
@@ -389,6 +408,69 @@ class HomeAssistantAPI:
         except Exception as e:
             _LOGGER.warning("SUPERNOTIFY Unable to get service info for %s.%s: %s", domain, service, e)
         return supports_response or SupportsResponse.NONE  # default to no response
+
+    async def load_service_descriptions(self) -> None:
+        """Cache the action descriptions (services.yaml) of every loaded integration.
+
+        Used to discover, without inspecting schemas, which actions accept the HA
+        target selectors (entity/device/area/floor/label), i.e. those declaring a
+        `target:` block in their description - the same signal the frontend uses.
+        """
+        if not self.hass_avail("services"):
+            return
+        try:
+            self._service_descriptions = await async_get_all_descriptions(self._hass)
+            _LOGGER.debug("SUPERNOTIFY Cached action descriptions for %s domains", len(self._service_descriptions))
+        except Exception as e:
+            _LOGGER.warning("SUPERNOTIFY Unable to load action descriptions: %s", e)
+
+    def service_accepts_target_selectors(self, qualified_action: str | None) -> bool | None:
+        """Discover whether an action accepts HA target selectors (area_id, floor_id, label_id)
+
+        Returns True if the action description declares a `target` block, False if the action is
+        known and doesn't, and None if the action is unknown or descriptions are unavailable.
+        """
+        if not qualified_action or "." not in qualified_action:
+            return None
+        domain, service = qualified_action.split(".", 1)
+        description: dict[str, Any] | None = self._service_descriptions.get(domain, {}).get(service)
+        if description is None and self.hass_avail("services"):
+            try:
+                description = async_get_cached_service_description(self._hass, domain, service)
+            except Exception as e:
+                _LOGGER.debug("SUPERNOTIFY Unable to get cached description for %s: %s", qualified_action, e)
+        if description is None:
+            return None
+        return description.get("target") is not None
+
+    def resolve_target_selectors(
+        self,
+        area_ids: list[str] | None = None,
+        floor_ids: list[str] | None = None,
+        label_ids: list[str] | None = None,
+    ) -> TargetSelectorResolution:
+        """Resolve HA area/floor/label selectors to the entities they reference, using the same
+        core helper as HA entity actions, so groups are expanded and device areas are honoured.
+        """
+        resolution = TargetSelectorResolution()
+        if not (area_ids or floor_ids or label_ids):
+            return resolution
+        selection: dict[str, list[str]] = {}
+        if area_ids:
+            selection[ATTR_AREA_ID] = list(area_ids)
+        if floor_ids:
+            selection[ATTR_FLOOR_ID] = list(floor_ids)
+        if label_ids:
+            selection[ATTR_LABEL_ID] = list(label_ids)
+        try:
+            selected = async_extract_referenced_entity_ids(self._hass, TargetSelection(selection), expand_group=True)
+            resolution.entity_ids = sorted(selected.referenced | selected.indirectly_referenced)
+            resolution.missing_areas = sorted(selected.missing_areas)
+            resolution.missing_floors = sorted(selected.missing_floors)
+            resolution.missing_labels = sorted(selected.missing_labels)
+        except Exception as e:
+            _LOGGER.warning("SUPERNOTIFY Unable to resolve target selectors %s: %s", selection, e)
+        return resolution
 
     def find_service(self, domain: str, module: str) -> str | None:
         try:

--- a/custom_components/supernotify/model.py
+++ b/custom_components/supernotify/model.py
@@ -258,8 +258,23 @@ class Target:
     def has_targets(self) -> bool:
         return any(targets for targets in self.targets.values())
 
-    def has_resolved_target(self) -> bool:
-        return any(targets for category, targets in self.targets.items() if category not in self.INDIRECT_CATEGORIES)
+    def has_resolved_target(self, include_selectors: bool = False) -> bool:
+        """True if any target remains after removing the indirect ones, optionally counting
+        area/floor/label selectors as resolved when they pass through to the action natively"""
+        return any(
+            targets
+            for category, targets in self.targets.items()
+            if category not in self.INDIRECT_CATEGORIES or (include_selectors and category in self.EXPLICIT_INDIRECT_CATEGORIES)
+        )
+
+    def has_selectors(self) -> bool:
+        return any(self.targets.get(category) for category in self.EXPLICIT_INDIRECT_CATEGORIES)
+
+    def selector_data(self) -> dict[str, list[str]]:
+        """area_id/floor_id/label_id targets in the shape of an HA action target block"""
+        return {
+            category: list(targets) for category in self.EXPLICIT_INDIRECT_CATEGORIES if (targets := self.targets.get(category))
+        }
 
     def has_unknown_targets(self) -> bool:
         return len(self.targets.get(self.UNKNOWN_CUSTOM_CATEGORY, [])) > 0
@@ -285,13 +300,18 @@ class Target:
     def direct_categories(self) -> list[str]:
         return self.DIRECT_CATEGORIES + [cat for cat in self.targets if cat not in self.CATEGORIES]
 
-    def direct(self) -> Target:
+    def direct(self, keep_selectors: bool = False) -> Target:
+        """Narrow to the direct targets, optionally keeping area/floor/label selectors for actions
+        that resolve them natively"""
+        categories: list[str] = self.direct_categories
+        if keep_selectors:
+            categories = categories + self.EXPLICIT_INDIRECT_CATEGORIES
         t = Target(
-            {cat: targets for cat, targets in self.targets.items() if cat in self.direct_categories},
+            {cat: targets for cat, targets in self.targets.items() if cat in categories},
             target_data=self.target_data,
         )
         if self.target_specific_data:
-            t.target_specific_data = {k: v for k, v in self.target_specific_data.items() if k[0] in self.direct_categories}
+            t.target_specific_data = {k: v for k, v in self.target_specific_data.items() if k[0] in categories}
         return t
 
     def extend(self, category: str, targets: list[str] | str) -> None:

--- a/custom_components/supernotify/notification.py
+++ b/custom_components/supernotify/notification.py
@@ -898,7 +898,7 @@ class Notification(ArchivableObject):
         split_targets: list[Target] = computed_target.split_by_target_data()
         self.debug_trace.record_target(delivery.name, "610_delivery_split_targets", split_targets)
 
-        direct_targets: list[Target] = [t.direct() for t in split_targets]
+        direct_targets: list[Target] = [t.direct(keep_selectors=delivery.passes_target_selectors) for t in split_targets]
         self.debug_trace.record_target(delivery.name, "620_narrow_to_direct", direct_targets)
 
         if delivery.options.get(OPTION_UNIQUE_TARGETS, False):
@@ -943,6 +943,9 @@ class Notification(ArchivableObject):
         resolved: Target = Target()
         additional: list[Target] = []
 
+        if target.has_selectors():
+            resolved += self.resolve_target_selectors(target, delivery)
+
         for person_id in target.person_ids:
             recipient: Recipient | None = self.people_registry.people.get(person_id)
             if recipient and recipient.enabled:
@@ -956,13 +959,49 @@ class Notification(ArchivableObject):
 
         return [resolved, *additional]
 
+    def resolve_target_selectors(self, target: Target, delivery: Delivery) -> Target:
+        """Resolve area_id/floor_id/label_id targets to entity_ids, unless the delivery's action
+        accepts the selectors natively, in which case they are left in place to pass through.
+
+        Resolution goes through the same core helper as HA entity actions, so groups are expanded
+        and entities inherit the area of their device; the transport's target selection then narrows
+        the entities to the ones it can deliver to. Unknown areas/floors/labels are logged, since
+        otherwise a typo silently resolves to nothing.
+        """
+        resolution = self.context.hass_api.resolve_target_selectors(
+            area_ids=target.area_ids, floor_ids=target.floor_ids, label_ids=target.label_ids
+        )
+        if resolution.has_missing():
+            _LOGGER.warning(
+                "SUPERNOTIFY Unknown target selectors for delivery %s: areas %s, floors %s, labels %s",
+                delivery.name,
+                resolution.missing_areas,
+                resolution.missing_floors,
+                resolution.missing_labels,
+            )
+        if delivery.passes_target_selectors:
+            _LOGGER.debug(
+                "SUPERNOTIFY Delivery %s passes target selectors through to %s (%s entities referenced)",
+                delivery.name,
+                delivery.action,
+                len(resolution.entity_ids),
+            )
+            return Target()
+        _LOGGER.debug(
+            "SUPERNOTIFY Delivery %s resolved target selectors to %s entities", delivery.name, len(resolution.entity_ids)
+        )
+        return Target({ATTR_ENTITY_ID: resolution.entity_ids}) if resolution.entity_ids else Target()
+
     def generate_envelopes(self, delivery: Delivery, targets: list[Target]) -> list[Envelope]:
         # now the list of recipients determined, resolve this to target addresses or entities
 
         envelopes: list[Envelope] = []
         for target in targets:
             # a target is always generated, even if there are no recipients
-            if target.has_resolved_target() or delivery.target_required != TargetRequired.ALWAYS:
+            if (
+                target.has_resolved_target(include_selectors=delivery.passes_target_selectors)
+                or delivery.target_required != TargetRequired.ALWAYS
+            ):
                 envelope_data = {}
 
                 # least priority - delivery derived data

--- a/custom_components/supernotify/transport.py
+++ b/custom_components/supernotify/transport.py
@@ -129,6 +129,20 @@ class Transport:
 
         """
 
+    def action_target(self, envelope: Envelope, entity_ids: list[str] | None = None) -> dict[str, Any]:  # type: ignore # noqa: F821
+        """Build the target block of an action call from entity ids, plus any area/floor/label
+        selectors the delivery passes through natively to the action"""
+        target_data: dict[str, Any] = {}
+        if entity_ids is not None:
+            target_data[ATTR_ENTITY_ID] = entity_ids
+        if envelope.delivery.passes_target_selectors and envelope.target is not None:
+            target_data.update(envelope.target.selector_data())
+        return target_data
+
+    @staticmethod
+    def has_action_target(target_data: dict[str, Any]) -> bool:
+        return any(target_data.values())
+
     def set_action_data(self, action_data: dict[str, Any], key: str, data: Any | None) -> dict[str, Any]:  # ruff: ignore[any-type]
         if data is not None:
             action_data[key] = data

--- a/custom_components/supernotify/transports/alexa_devices.py
+++ b/custom_components/supernotify/transports/alexa_devices.py
@@ -67,13 +67,12 @@ class AlexaDevicesTransport(Transport):
     async def deliver(self, envelope: Envelope, debug_trace: DebugTrace | None = None) -> bool:
         _LOGGER.debug("SUPERNOTIFY notify_alexa_devices: %s", envelope.message)
 
-        targets = envelope.target.entity_ids or []
+        target_data: dict[str, Any] = self.action_target(envelope, envelope.target.entity_ids or None)
 
-        if not targets:
+        if not self.has_action_target(target_data):
             _LOGGER.debug("SUPERNOTIFY Skipping alexa devices, no targets")
             return False
 
         action_data: dict[str, Any] = {ATTR_MESSAGE: envelope.message or ""}
-        target_data: dict[str, Any] = {ATTR_ENTITY_ID: targets}
 
         return await self.call_action(envelope, action_data=action_data, target_data=target_data)

--- a/custom_components/supernotify/transports/chime.py
+++ b/custom_components/supernotify/transports/chime.py
@@ -27,9 +27,11 @@ from custom_components.supernotify.const import (
     OPTION_DEVICE_MODEL_SELECT,
     OPTION_TARGET_CATEGORIES,
     OPTION_TARGET_SELECT,
+    OPTION_TARGET_SELECTORS,
     OPTIONS_CHIME_DOMAINS,
     RE_DEVICE_ID,
     SELECT_EXCLUDE,
+    TARGET_SELECTORS_RESOLVE,
     TRANSPORT_CHIME,
 )
 from custom_components.supernotify.model import (
@@ -279,6 +281,8 @@ class ChimeTransport(Transport):
         config.delivery_defaults.target_required = TargetRequired.OPTIONAL
         config.delivery_defaults.options = {
             OPTION_TARGET_CATEGORIES: [ATTR_ENTITY_ID, ATTR_DEVICE_ID],
+            # chimes are actioned one entity at a time, so area/floor/label are resolved to entities here
+            OPTION_TARGET_SELECTORS: TARGET_SELECTORS_RESOLVE,
             OPTION_TARGET_SELECT: [RE_VALID_CHIME, RE_DEVICE_ID],
             OPTION_DEVICE_DISCOVERY: True,
             OPTION_DEVICE_DOMAIN: DEVICE_DOMAINS,

--- a/custom_components/supernotify/transports/generic.py
+++ b/custom_components/supernotify/transports/generic.py
@@ -163,20 +163,20 @@ class GenericTransport(Transport):
             if qualified_action == "notify.send_message":
                 # amongst the wild west of notifty handling, at least care for the modern core one
                 action_data = core_action_data
-                target_data = {ATTR_ENTITY_ID: envelope.target.domain_entity_ids(domain)}
+                target_data = self.action_target(envelope, envelope.target.domain_entity_ids(domain))
                 prune_data = False
             else:
                 action_data = core_action_data
                 action_data[ATTR_DATA] = data
                 build_targets = True
         elif equiv_domain == "input_text":
-            target_data = {ATTR_ENTITY_ID: envelope.target.domain_entity_ids(domain)}
+            target_data = self.action_target(envelope, envelope.target.domain_entity_ids(domain))
             if "value" in data:
                 action_data = {"value": data["value"]}
             else:
                 action_data = {"value": core_action_data[ATTR_MESSAGE]}
         elif equiv_domain == "switch":
-            target_data = {ATTR_ENTITY_ID: envelope.target.domain_entity_ids(domain)}
+            target_data = self.action_target(envelope, envelope.target.domain_entity_ids(domain))
         elif equiv_domain == "mqtt":
             action_data = data
             if "payload" not in action_data:
@@ -191,7 +191,7 @@ class GenericTransport(Transport):
         elif qualified_action == "ntfy.publish":
             mini_envelopes.extend(ntfy(core_action_data, data, envelope.target, envelope.delivery, self.hass_api))
         elif equiv_domain in ("siren", "light"):
-            target_data = {ATTR_ENTITY_ID: envelope.target.domain_entity_ids(domain)}
+            target_data = self.action_target(envelope, envelope.target.domain_entity_ids(domain))
             action_data = data
         elif equiv_domain == "rest_command":
             action_data = data

--- a/custom_components/supernotify/transports/html5.py
+++ b/custom_components/supernotify/transports/html5.py
@@ -212,7 +212,7 @@ class HTML5Transport(Transport):
 
         # Resolve and pre-validate notify entity targets
         targets = self.select_targets(envelope)
-        if not targets:
+        if not targets and not self.has_action_target(self.action_target(envelope)):
             _LOGGER.warning("SUPERNOTIFY html5: no valid targets (expected notify.* entities)")
             self.record_error("no valid html5 notify entity targets", "deliver")
             return False
@@ -303,5 +303,5 @@ class HTML5Transport(Transport):
                 sorted(raw_data),
             )
 
-        target_data = {ATTR_ENTITY_ID: targets}
+        target_data = self.action_target(envelope, targets)
         return await self.call_action(envelope, action_data=action_data, target_data=target_data)

--- a/custom_components/supernotify/transports/kodi.py
+++ b/custom_components/supernotify/transports/kodi.py
@@ -208,7 +208,7 @@ class KodiTransport(Transport):
 
         # Resolve and pre-validate media_player targets
         targets = self.select_targets(envelope)
-        if not targets:
+        if not targets and not self.has_action_target(self.action_target(envelope)):
             _LOGGER.warning("SUPERNOTIFY kodi: no valid media_player targets")
             self.record_error("no valid Kodi media_player targets", "deliver")
             return False
@@ -264,5 +264,5 @@ class KodiTransport(Transport):
         return await self.call_action(
             envelope,
             action_data=action_data,
-            target_data={ATTR_ENTITY_ID: targets},
+            target_data=self.action_target(envelope, targets),
         )

--- a/custom_components/supernotify/transports/media_player.py
+++ b/custom_components/supernotify/transports/media_player.py
@@ -50,9 +50,9 @@ class MediaPlayerTransport(Transport):
         _LOGGER.debug("SUPERNOTIFY notify_media: %s", envelope.data)
 
         data: dict[str, Any] = envelope.data or {}
-        media_players: list[str] = envelope.target.entity_ids or []
+        target_data: dict[str, Any] = self.action_target(envelope, envelope.target.entity_ids or None)
         media_type: str = data.get("media_content_type", "image")
-        if not media_players:
+        if not self.has_action_target(target_data):
             _LOGGER.debug("SUPERNOTIFY Skipping media show, no targets")
             return False
 
@@ -72,4 +72,4 @@ class MediaPlayerTransport(Transport):
         if data and data.get("enqueue"):
             action_data["enqueue"] = data.get("enqueue")
 
-        return await self.call_action(envelope, action_data=action_data, target_data={ATTR_ENTITY_ID: media_players})
+        return await self.call_action(envelope, action_data=action_data, target_data=target_data)

--- a/custom_components/supernotify/transports/notify_entity.py
+++ b/custom_components/supernotify/transports/notify_entity.py
@@ -67,14 +67,10 @@ class NotifyEntityTransport(Transport):
         return self.delivery_defaults
 
     async def deliver(self, envelope: Envelope, debug_trace: DebugTrace | None = None) -> bool:
-        targets = envelope.target.entity_ids or []
-        if not targets:
+        target_data: dict[str, Any] = self.action_target(envelope, envelope.target.entity_ids or None)
+        if not self.has_action_target(target_data):
             _LOGGER.warning("SUPERNOTIFY notify_entity: no targets")
             return False
-        target_data: dict[str, Any] = {ATTR_ENTITY_ID: targets}
-        # area_id
-        # device_id
-        # label_id
         action_data = envelope.core_action_data()
 
         return await self.call_action(envelope, FIXED_ACTION, action_data=action_data, target_data=target_data)

--- a/custom_components/supernotify/transports/tts.py
+++ b/custom_components/supernotify/transports/tts.py
@@ -18,8 +18,10 @@ from custom_components.supernotify.const import (
     OPTION_STRIP_URLS,
     OPTION_TARGET_CATEGORIES,
     OPTION_TARGET_SELECT,
+    OPTION_TARGET_SELECTORS,
     OPTION_TTS_ENTITY_ID,
     SELECT_EXCLUDE,
+    TARGET_SELECTORS_RESOLVE,
     TRANSPORT_TTS,
 )
 from custom_components.supernotify.model import (
@@ -76,6 +78,9 @@ class TTSTransport(Transport):
             OPTION_STRIP_URLS: True,
             OPTION_MESSAGE_USAGE: MessageOnlyPolicy.STANDARD,
             OPTION_TARGET_CATEGORIES: [ATTR_ENTITY_ID, ATTR_MOBILE_APP_ID],
+            # tts.speak targets the TTS engine entity, media players are action data, so area/floor/label
+            # must be resolved to media_player entities here rather than passed through
+            OPTION_TARGET_SELECTORS: TARGET_SELECTORS_RESOLVE,
             OPTION_TARGET_SELECT: [RE_VALID_MEDIA_PLAYER, RE_MOBILE_APP],
             OPTION_TTS_ENTITY_ID: "tts.home_assistant_cloud",
             OPTION_DEVICE_DISCOVERY: False,

--- a/docs/configuration/deliveries.md
+++ b/docs/configuration/deliveries.md
@@ -115,6 +115,17 @@ are resolved as specific to it, for example based on the `target_categories` opt
 - `never` - Don't require targets, and don't even waste time computing them and don't supply them to the transport adaptor
 - `optional` - Don't require targets but still compute them and make them available for the notification
 
+Home Assistant `area_id`, `floor_id` and `label_id` targets are handled according to the `target_selectors` option:
+
+- `auto` - the default, pass the selectors through untouched if the delivery's action declares that it accepts
+  targets ( as `notify.send_message` does ), otherwise resolve them within Supernotify
+- `native` - always pass the selectors through to the action, for example when the action is known to accept them but isn't described that way
+- `resolve` - always resolve the selectors to entities within Supernotify first, using the same core logic as
+  Home Assistant actions, so groups are expanded and entities inherit the area of their device, and then apply the
+  delivery's `target_categories` and `target_select` options to the result
+
+The `tts` and `chime` transports default to `resolve`, since their actions are targeted per entity rather than by the notification target.
+
 ## Delivery Selection
 
 A list of `selection` options controls how deliveries are selected, each delivery can have multiple

--- a/docs/transports/index.md
+++ b/docs/transports/index.md
@@ -51,6 +51,7 @@ All of these set by passing an `options` block in Delivery config or Transport d
 | strip_urls                 | bool      | all        | Remove URLs from message and title                                           |
 | target_categories          | list      | all        | Which targets to pass, e.g. `entity_id`,`email`,`device_id`                  |
 | target_select              | Selection | all        | Only use targets fully matching these regular expressions                    |
+| target_selectors           | str       | all        | `auto`,`native` or `resolve` for how `area_id`,`floor_id`,`label_id` targets are handled |
 | unique_targets             | bool      | all        | Don't pass targets already used in this notification                         |
 | data_keys_select           | Selection | generic    | Prune `data` block by including/excluding values or by regex pattern.        |
 | handle_as_domain           | bool      | generic    | Treat the action call in same way as a known domain                          |

--- a/docs/usage/notifying.md
+++ b/docs/usage/notifying.md
@@ -80,6 +80,30 @@ is most convenient
               - mobile_app.john_ipad
 ```
 
+## Area, Floor and Label Targets
+
+Home Assistant's standard target selectors can be used as well as addresses and entities, so a notification
+can go to "whatever is in the kitchen" or "everything labelled `chime`", using the same `area_id`, `floor_id`
+and `label_id` keys as any other Home Assistant action:
+
+```yaml
+  - action: supernotify.notify
+    data:
+        message: Dinner is ready
+        target:
+            area_id: kitchen
+            floor_id: ground_floor
+            label_id:
+              - chime
+```
+
+For each delivery, Supernotify either passes the selectors straight through to the underlying action, where
+that action supports them (for example `notify.send_message` for notify entities), or resolves them to
+entities itself using the same core logic as Home Assistant actions, and then applies the delivery's usual
+target selection. This is decided automatically from the action definition, and can be forced with the
+`target_selectors` delivery option, see [Deliveries](../configuration/deliveries.md#controlling-targets).
+Unknown areas, floors or labels are logged as a warning rather than silently resolving to nothing.
+
 ## Notification Priority
 
 Use the `priority` key in `data` to set an optional priority. This can be used within Supernotify to switch on or off deliveries or scenarios ( for example a siren to accompany 'critical' notifications).

--- a/tests/components/supernotify/test_target_selectors.py
+++ b/tests/components/supernotify/test_target_selectors.py
@@ -1,0 +1,459 @@
+"""Tests for area_id / floor_id / label_id target selectors (issue #9).
+
+Selectors are either passed through untouched to actions that accept them natively (discovered
+from the action description, or forced with the `target_selectors` delivery option), or resolved
+to entity_ids within supernotify using the same core helper as HA entity actions.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from homeassistant.const import ATTR_AREA_ID, ATTR_ENTITY_ID, ATTR_FLOOR_ID, ATTR_LABEL_ID, CONF_ACTION, CONF_TARGET
+from homeassistant.helpers import area_registry as ar
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import floor_registry as fr
+from homeassistant.helpers import label_registry as lr
+
+from custom_components.supernotify.const import (
+    CONF_DELIVERY,
+    CONF_OPTIONS,
+    CONF_TARGET_REQUIRED,
+    CONF_TRANSPORT,
+    OPTION_TARGET_SELECTORS,
+    TARGET_SELECTORS_NATIVE,
+    TARGET_SELECTORS_RESOLVE,
+    TRANSPORT_CHIME,
+    TRANSPORT_GENERIC,
+    TRANSPORT_NOTIFY_ENTITY,
+    TRANSPORT_TTS,
+)
+from custom_components.supernotify.delivery import Delivery
+from custom_components.supernotify.envelope import Envelope
+from custom_components.supernotify.hass_api import HomeAssistantAPI, TargetSelectorResolution
+from custom_components.supernotify.model import Target
+from custom_components.supernotify.notification import Notification
+from custom_components.supernotify.transports.notify_entity import NotifyEntityTransport
+from tests.components.supernotify.hass_setup_lib import TestingContext
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from custom_components.supernotify.context import Context
+
+# ---------------------------------------------------------------------------
+# Target model
+# ---------------------------------------------------------------------------
+
+
+def test_target_selector_helpers() -> None:
+    uut = Target({ATTR_ENTITY_ID: ["light.a"], ATTR_AREA_ID: ["kitchen"], ATTR_FLOOR_ID: [], ATTR_LABEL_ID: ["chimes"]})
+    assert uut.has_selectors()
+    assert uut.selector_data() == {ATTR_AREA_ID: ["kitchen"], ATTR_LABEL_ID: ["chimes"]}
+    assert not Target(["light.a"]).has_selectors()
+    assert Target(["light.a"]).selector_data() == {}
+
+
+def test_target_direct_drops_selectors_by_default() -> None:
+    uut = Target({ATTR_ENTITY_ID: ["light.a"], ATTR_AREA_ID: ["kitchen"], "person_id": ["person.bob"]})
+    assert uut.direct() == Target({ATTR_ENTITY_ID: ["light.a"]})
+    assert uut.direct(keep_selectors=True) == Target({ATTR_ENTITY_ID: ["light.a"], ATTR_AREA_ID: ["kitchen"]})
+
+
+def test_target_direct_keeps_selector_specific_data() -> None:
+    uut = Target({ATTR_AREA_ID: ["kitchen"], "person_id": ["person.bob"]}, target_data={"x": 1}, target_specific_data=True)
+    assert uut.direct().target_specific_data == {}
+    assert uut.direct(keep_selectors=True).target_specific_data == {(ATTR_AREA_ID, "kitchen"): {"x": 1}}
+
+
+def test_target_selectors_only_resolved_when_included() -> None:
+    uut = Target({ATTR_AREA_ID: ["kitchen"]})
+    assert not uut.has_resolved_target()
+    assert uut.has_resolved_target(include_selectors=True)
+    assert not Target({"person_id": ["person.bob"]}).has_resolved_target(include_selectors=True)
+
+
+# ---------------------------------------------------------------------------
+# HomeAssistantAPI: discovery and resolution
+# ---------------------------------------------------------------------------
+
+
+def test_service_accepts_target_selectors_from_cached_descriptions(hass: HomeAssistant) -> None:
+    uut = HomeAssistantAPI(hass)
+    uut._service_descriptions = {
+        "notify": {
+            "send_message": {"fields": {}, "target": {"entity": [{"domain": ["notify"]}]}},
+            "legacy_thing": {"fields": {"target": {}}},
+        }
+    }
+    assert uut.service_accepts_target_selectors("notify.send_message") is True
+    assert uut.service_accepts_target_selectors("notify.legacy_thing") is False
+    assert uut.service_accepts_target_selectors("notify.unknown") is None
+    assert uut.service_accepts_target_selectors("no_dot") is None
+    assert uut.service_accepts_target_selectors(None) is None
+
+
+def test_service_accepts_target_selectors_falls_back_to_hass_cache(hass: HomeAssistant) -> None:
+    uut = HomeAssistantAPI(hass)
+    with patch(
+        "custom_components.supernotify.hass_api.async_get_cached_service_description",
+        return_value={"target": {"entity": []}},
+    ) as cached:
+        assert uut.service_accepts_target_selectors("kodi.call_method") is True
+    cached.assert_called_once_with(hass, "kodi", "call_method")
+
+
+def test_service_accepts_target_selectors_survives_cache_errors(hass: HomeAssistant) -> None:
+    uut = HomeAssistantAPI(hass)
+    with patch("custom_components.supernotify.hass_api.async_get_cached_service_description", side_effect=RuntimeError("boom")):
+        assert uut.service_accepts_target_selectors("kodi.call_method") is None
+
+
+async def test_load_service_descriptions(hass: HomeAssistant) -> None:
+    uut = HomeAssistantAPI(hass)
+    descriptions = {"tts": {"speak": {"target": {"entity": []}}}}
+    with patch("custom_components.supernotify.hass_api.async_get_all_descriptions", AsyncMock(return_value=descriptions)):
+        await uut.load_service_descriptions()
+    assert uut.service_accepts_target_selectors("tts.speak") is True
+
+
+async def test_load_service_descriptions_tolerates_failure(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
+    uut = HomeAssistantAPI(hass)
+    with patch(
+        "custom_components.supernotify.hass_api.async_get_all_descriptions", AsyncMock(side_effect=RuntimeError("boom"))
+    ):
+        await uut.load_service_descriptions()
+    assert uut._service_descriptions == {}
+    assert "Unable to load action descriptions" in caplog.text
+
+
+async def test_load_service_descriptions_skipped_without_hass() -> None:
+    uut = HomeAssistantAPI(Mock(services=None))
+    with patch("custom_components.supernotify.hass_api.async_get_all_descriptions", AsyncMock()) as loader:
+        await uut.load_service_descriptions()
+    loader.assert_not_called()
+
+
+def test_resolve_target_selectors_empty(hass: HomeAssistant) -> None:
+    uut = HomeAssistantAPI(hass)
+    resolution = uut.resolve_target_selectors()
+    assert resolution.entity_ids == []
+    assert not resolution.has_missing()
+
+
+def _register_entity(hass: HomeAssistant, domain: str, uid: str, area_id: str | None = None) -> str:
+    registry = er.async_get(hass)
+    entry = registry.async_get_or_create(domain, "unit_test", uid, suggested_object_id=uid)
+    if area_id:
+        entry = registry.async_update_entity(entry.entity_id, area_id=area_id)
+    hass.states.async_set(entry.entity_id, "on")
+    return entry.entity_id
+
+
+def test_resolve_target_selectors_by_area_floor_label(hass: HomeAssistant) -> None:
+    uut = HomeAssistantAPI(hass)
+    floor = fr.async_get(hass).async_create("Ground")
+    kitchen = ar.async_get(hass).async_create("Kitchen", floor_id=floor.floor_id)
+    lounge = ar.async_get(hass).async_create("Lounge", floor_id=floor.floor_id)
+    attic = ar.async_get(hass).async_create("Attic")
+    label = lr.async_get(hass).async_create("Chimes")
+
+    kitchen_chime = _register_entity(hass, "switch", "kitchen_chime", area_id=kitchen.id)
+    kitchen_light = _register_entity(hass, "light", "kitchen_light", area_id=kitchen.id)
+    lounge_speaker = _register_entity(hass, "media_player", "lounge_speaker", area_id=lounge.id)
+    attic_chime = _register_entity(hass, "switch", "attic_chime", area_id=attic.id)
+    er.async_get(hass).async_update_entity(attic_chime, labels={label.label_id})
+    er.async_get(hass).async_update_entity(kitchen_chime, labels={label.label_id})
+
+    by_area = uut.resolve_target_selectors(area_ids=[kitchen.id])
+    assert by_area.entity_ids == sorted([kitchen_chime, kitchen_light])
+    assert not by_area.has_missing()
+
+    by_floor = uut.resolve_target_selectors(floor_ids=[floor.floor_id])
+    assert by_floor.entity_ids == sorted([kitchen_chime, kitchen_light, lounge_speaker])
+
+    by_label = uut.resolve_target_selectors(label_ids=[label.label_id])
+    assert by_label.entity_ids == sorted([attic_chime, kitchen_chime])
+
+    # overlapping selectors dedupe to a single entity set
+    combined = uut.resolve_target_selectors(area_ids=[kitchen.id], floor_ids=[floor.floor_id], label_ids=[label.label_id])
+    assert combined.entity_ids == sorted([attic_chime, kitchen_chime, kitchen_light, lounge_speaker])
+
+
+def test_resolve_target_selectors_reports_missing(hass: HomeAssistant) -> None:
+    uut = HomeAssistantAPI(hass)
+    resolution = uut.resolve_target_selectors(area_ids=["nowhere"], floor_ids=["basement"], label_ids=["nope"])
+    assert resolution.entity_ids == []
+    assert resolution.has_missing()
+    assert resolution.missing_areas == ["nowhere"]
+    assert resolution.missing_floors == ["basement"]
+    assert resolution.missing_labels == ["nope"]
+
+
+def test_resolve_target_selectors_survives_errors(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -> None:
+    uut = HomeAssistantAPI(hass)
+    with patch("custom_components.supernotify.hass_api.async_extract_referenced_entity_ids", side_effect=RuntimeError("boom")):
+        resolution = uut.resolve_target_selectors(area_ids=["kitchen"])
+    assert resolution.entity_ids == []
+    assert "Unable to resolve target selectors" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Delivery: discovery and target selection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("option", "discovered", "expected"),
+    [
+        (TARGET_SELECTORS_NATIVE, None, True),
+        (TARGET_SELECTORS_NATIVE, False, True),
+        (TARGET_SELECTORS_RESOLVE, True, False),
+        ("auto", True, True),
+        ("auto", False, False),
+        ("auto", None, False),
+        (None, True, True),
+        (None, None, False),
+        ("garbage", True, True),
+    ],
+)
+async def test_delivery_discovers_target_selectors(
+    mock_context: Context, option: str | None, discovered: bool | None, expected: bool
+) -> None:
+    mock_context.hass_api.service_accepts_target_selectors = Mock(return_value=discovered)
+    conf = {CONF_OPTIONS: {OPTION_TARGET_SELECTORS: option}} if option else {}
+    uut = Delivery("unit_testing", conf, NotifyEntityTransport(mock_context, {}))
+    assert uut.passes_target_selectors is False
+    assert await uut.initialize(mock_context)
+    assert uut.passes_target_selectors is expected
+
+
+async def test_delivery_warns_on_unknown_target_selectors_option(
+    mock_context: Context, caplog: pytest.LogCaptureFixture
+) -> None:
+    mock_context.hass_api.service_accepts_target_selectors = Mock(return_value=None)
+    uut = Delivery(
+        "unit_testing", {CONF_OPTIONS: {OPTION_TARGET_SELECTORS: "garbage"}}, NotifyEntityTransport(mock_context, {})
+    )
+    await uut.initialize(mock_context)
+    assert "unknown target_selectors option garbage" in caplog.text
+
+
+async def test_delivery_selection_drops_selectors_unless_passed_through() -> None:
+    ctx = TestingContext(transport_types=[NotifyEntityTransport])
+    await ctx.test_initialize()
+    uut = Delivery("unit_testing", {}, NotifyEntityTransport(ctx, {}))
+    target = Target({ATTR_ENTITY_ID: ["notify.pong", "light.nope"], ATTR_AREA_ID: ["kitchen"], ATTR_LABEL_ID: ["chimes"]})
+
+    uut.passes_target_selectors = False
+    assert uut.select_targets(target) == Target(["notify.pong"])
+
+    # selectors are neither category-filtered nor regex-filtered when passed through
+    uut.passes_target_selectors = True
+    assert uut.select_targets(target) == Target({
+        ATTR_ENTITY_ID: ["notify.pong"],
+        ATTR_AREA_ID: ["kitchen"],
+        ATTR_LABEL_ID: ["chimes"],
+    })
+
+
+async def test_tts_and_chime_default_to_local_resolution() -> None:
+    ctx = TestingContext(
+        deliveries={
+            "speak": {CONF_TRANSPORT: TRANSPORT_TTS, CONF_ACTION: "tts.speak"},
+            "ding": {CONF_TRANSPORT: TRANSPORT_CHIME},
+        }
+    )
+    await ctx.test_initialize()
+    assert ctx.delivery("speak").options[OPTION_TARGET_SELECTORS] == TARGET_SELECTORS_RESOLVE
+    assert ctx.delivery("ding").options[OPTION_TARGET_SELECTORS] == TARGET_SELECTORS_RESOLVE
+    assert ctx.delivery("speak").passes_target_selectors is False
+    assert ctx.delivery("ding").passes_target_selectors is False
+
+
+# ---------------------------------------------------------------------------
+# Notification: target generation end to end
+# ---------------------------------------------------------------------------
+
+
+async def _generic_context(**options: str) -> TestingContext:
+    ctx = TestingContext(
+        deliveries={
+            "chatty": {
+                CONF_ACTION: "custom.tweak",
+                CONF_TRANSPORT: TRANSPORT_GENERIC,
+                CONF_OPTIONS: dict(options),
+            }
+        }
+    )
+    await ctx.test_initialize()
+    return ctx
+
+
+async def test_generate_targets_resolves_area_to_entities() -> None:
+    ctx = await _generic_context(**{OPTION_TARGET_SELECTORS: TARGET_SELECTORS_RESOLVE})
+    delivery = ctx.delivery("chatty")
+    resolution = TargetSelectorResolution(entity_ids=["custom.light_1", "custom.switch_2"])
+    with patch.object(ctx.hass_api, "resolve_target_selectors", return_value=resolution) as resolver:
+        uut = Notification(ctx, "testing 123", target={ATTR_AREA_ID: ["kitchen"], ATTR_ENTITY_ID: ["custom.switch_2"]})
+        targets: list[Target] = uut.generate_targets(delivery)
+    resolver.assert_called_once_with(area_ids=["kitchen"], floor_ids=[], label_ids=[])
+    assert len(targets) == 1
+    # deduped against the explicit entity target, and the selector itself dropped
+    assert targets[0].entity_ids == ["custom.switch_2", "custom.light_1"]
+    assert targets[0].area_ids == []
+
+
+async def test_generate_targets_passes_selectors_through_natively() -> None:
+    ctx = await _generic_context(**{OPTION_TARGET_SELECTORS: TARGET_SELECTORS_NATIVE})
+    delivery = ctx.delivery("chatty")
+    resolution = TargetSelectorResolution(entity_ids=["custom.light_1"])
+    with patch.object(ctx.hass_api, "resolve_target_selectors", return_value=resolution):
+        uut = Notification(ctx, "testing 123", target={ATTR_AREA_ID: ["kitchen"], ATTR_FLOOR_ID: ["ground"]})
+        targets: list[Target] = uut.generate_targets(delivery)
+    assert len(targets) == 1
+    assert targets[0].entity_ids == []
+    assert targets[0].area_ids == ["kitchen"]
+    assert targets[0].floor_ids == ["ground"]
+
+
+async def test_generate_targets_warns_on_unknown_selectors(caplog: pytest.LogCaptureFixture) -> None:
+    ctx = await _generic_context()
+    delivery = ctx.delivery("chatty")
+    resolution = TargetSelectorResolution(missing_areas=["kitchn"], missing_labels=["chime"])
+    with patch.object(ctx.hass_api, "resolve_target_selectors", return_value=resolution):
+        uut = Notification(ctx, "testing 123", target={ATTR_AREA_ID: ["kitchn"], ATTR_LABEL_ID: ["chime"]})
+        targets: list[Target] = uut.generate_targets(delivery)
+    assert targets[0].entity_ids == []
+    assert targets[0].area_ids == []
+    assert "Unknown target selectors for delivery chatty: areas ['kitchn'], floors [], labels ['chime']" in caplog.text
+
+
+async def test_generate_envelopes_for_native_selectors_when_target_required() -> None:
+    ctx = TestingContext(
+        deliveries={
+            "chatty": {
+                CONF_ACTION: "custom.tweak",
+                CONF_TRANSPORT: TRANSPORT_GENERIC,
+                CONF_TARGET_REQUIRED: "always",
+                CONF_OPTIONS: {OPTION_TARGET_SELECTORS: TARGET_SELECTORS_NATIVE},
+            },
+            "quiet": {
+                CONF_ACTION: "custom.tweak",
+                CONF_TRANSPORT: TRANSPORT_GENERIC,
+                CONF_TARGET_REQUIRED: "always",
+                CONF_OPTIONS: {OPTION_TARGET_SELECTORS: TARGET_SELECTORS_RESOLVE},
+            },
+        }
+    )
+    await ctx.test_initialize()
+    with patch.object(ctx.hass_api, "resolve_target_selectors", return_value=TargetSelectorResolution()):
+        uut = Notification(ctx, "testing 123", target={ATTR_AREA_ID: ["kitchen"]})
+        native = uut.generate_envelopes(ctx.delivery("chatty"), uut.generate_targets(ctx.delivery("chatty")))
+        resolved = uut.generate_envelopes(ctx.delivery("quiet"), uut.generate_targets(ctx.delivery("quiet")))
+    assert len(native) == 1
+    assert native[0].target.area_ids == ["kitchen"]
+    # nothing in the area, and selectors don't pass through, so no envelope at all
+    assert resolved == []
+
+
+async def test_delivery_override_target_resolves_selectors() -> None:
+    ctx = await _generic_context()
+    delivery = ctx.delivery("chatty")
+    resolution = TargetSelectorResolution(entity_ids=["custom.light_1"])
+    with patch.object(ctx.hass_api, "resolve_target_selectors", return_value=resolution):
+        uut = Notification(
+            ctx,
+            "testing 123",
+            target=["custom.switch_9"],
+            action_data={CONF_DELIVERY: {"chatty": {CONF_TARGET: {ATTR_LABEL_ID: ["lights"]}}}},
+        )
+        targets: list[Target] = uut.generate_targets(delivery)
+    assert targets[0].entity_ids == ["custom.light_1"]
+    assert targets[0].label_ids == []
+
+
+# ---------------------------------------------------------------------------
+# Transport: native pass through of selectors in the action target
+# ---------------------------------------------------------------------------
+
+
+async def test_notify_entity_passes_selectors_to_action(mock_hass, unmocked_config) -> None:  # type: ignore
+    context = unmocked_config
+    uut = NotifyEntityTransport(context)
+    await uut.initialize()
+    context.configure_for_tests([uut])
+    await context.initialize()
+    delivery = Delivery(
+        "ping", {CONF_TRANSPORT: TRANSPORT_NOTIFY_ENTITY, CONF_OPTIONS: {OPTION_TARGET_SELECTORS: "native"}}, uut
+    )
+    await delivery.initialize(context)
+    assert delivery.passes_target_selectors
+    assert await uut.deliver(
+        Envelope(
+            delivery,
+            Notification(context, message="hello there"),
+            target=Target({ATTR_ENTITY_ID: ["notify.pong"], ATTR_AREA_ID: ["kitchen"], ATTR_LABEL_ID: ["phones"]}),
+        )
+    )
+    context.hass_api.call_service.assert_called_with(
+        "notify",
+        "send_message",
+        service_data={"message": "hello there"},
+        target={ATTR_ENTITY_ID: ["notify.pong"], ATTR_AREA_ID: ["kitchen"], ATTR_LABEL_ID: ["phones"]},
+        debug=False,
+        context=None,
+    )
+
+
+async def test_notify_entity_delivers_on_selectors_alone(mock_hass, unmocked_config) -> None:  # type: ignore
+    context = unmocked_config
+    uut = NotifyEntityTransport(context)
+    await uut.initialize()
+    context.configure_for_tests([uut])
+    await context.initialize()
+    delivery = Delivery(
+        "ping", {CONF_TRANSPORT: TRANSPORT_NOTIFY_ENTITY, CONF_OPTIONS: {OPTION_TARGET_SELECTORS: "native"}}, uut
+    )
+    await delivery.initialize(context)
+    assert await uut.deliver(
+        Envelope(delivery, Notification(context, message="hello there"), target=Target({ATTR_AREA_ID: ["kitchen"]}))
+    )
+    context.hass_api.call_service.assert_called_with(
+        "notify",
+        "send_message",
+        service_data={"message": "hello there"},
+        target={ATTR_AREA_ID: ["kitchen"]},
+        debug=False,
+        context=None,
+    )
+
+
+async def test_notify_entity_ignores_selectors_when_resolving(mock_hass, unmocked_config) -> None:  # type: ignore
+    context = unmocked_config
+    uut = NotifyEntityTransport(context)
+    await uut.initialize()
+    context.configure_for_tests([uut])
+    await context.initialize()
+    delivery = Delivery("ping", {CONF_TRANSPORT: TRANSPORT_NOTIFY_ENTITY}, uut)
+    await delivery.initialize(context)
+    assert not delivery.passes_target_selectors
+    assert not await uut.deliver(
+        Envelope(delivery, Notification(context, message="hello there"), target=Target({ATTR_AREA_ID: ["kitchen"]}))
+    )
+    context.hass_api.call_service.assert_not_called()
+
+
+def test_action_target_helper(mock_context: Context) -> None:
+    uut = NotifyEntityTransport(mock_context, {})
+    delivery = Delivery("ping", {}, uut)
+    envelope = Envelope(delivery, Notification(mock_context, message="x"), target=Target({ATTR_AREA_ID: ["kitchen"]}))
+    assert uut.action_target(envelope, ["notify.a"]) == {ATTR_ENTITY_ID: ["notify.a"]}
+    assert uut.action_target(envelope, []) == {ATTR_ENTITY_ID: []}
+    assert not uut.has_action_target(uut.action_target(envelope, []))
+    delivery.passes_target_selectors = True
+    assert uut.action_target(envelope, ["notify.a"]) == {ATTR_ENTITY_ID: ["notify.a"], ATTR_AREA_ID: ["kitchen"]}
+    assert uut.action_target(envelope) == {ATTR_AREA_ID: ["kitchen"]}
+    assert uut.has_action_target(uut.action_target(envelope))


### PR DESCRIPTION
## Support area, floor and label target selectors

Closes #9

### Problem

Since 2.3.0 `supernotify.notify` uses `selector: target:`, so the UI already offers areas, floors and labels as targets, and `TARGET_SCHEMA` accepts them. But nothing downstream used them: they were dropped at delivery selection (`330_delivery_selection`, since no transport lists them in `target_categories`) and again at `620_narrow_to_direct`. Picking "Living Room" either silently produced no envelope (`target_required: always`) or fell back to the delivery's default recipients.

### Approach

As discussed on #9: dynamic discovery by default, an explicit override only where discovery can't be trusted, and local resolution for everything else.

- **Discovery** — a delivery passes selectors through to its action when the action's *description* declares a `target` block (the same signal the frontend uses to show the area/floor/label pickers). Descriptions are cached once at startup via `async_get_all_descriptions`, with `async_get_cached_service_description` as fallback. I went with descriptions rather than inspecting `Service.schema` because HA 2026.9 registers schemas as `probatio.schema.Schema` while 2026.2 still uses voluptuous, so schema introspection isn't portable across the two supported lanes.
- **Native pass-through** — the selectors stay in the target through selection and `direct()`, and the transports that build an HA target block (`notify_entity`, `alexa_devices`, `media_player`, `kodi`, `html5`, `generic`) forward them via a shared `Transport.action_target()` helper, so HA does the platform narrowing.
- **Local resolution** — otherwise selectors are resolved in `Notification.resolve_indirect_targets()` through `homeassistant.helpers.target.async_extract_referenced_entity_ids(hass, TargetSelection(...), expand_group=True)`: groups expanded, entities inherit their device's area, and overlapping selectors/explicit targets dedupe by construction (level (1) of the dedup discussion). The delivery's existing `target_categories` / `target_select` then narrow the entities to what the transport can deliver to. Resolution yields entity_ids only, never device_ids, so chime doesn't try to ring every device in a room.
- **Override** — new `target_selectors` delivery option: `auto` (default), `native`, `resolve`. `tts` and `chime` default to `resolve`: `tts.speak` does declare a target, but it's the TTS engine entity, not the media players, and chime actions one entity at a time.
- **Diagnostics** — unknown areas/floors/labels are logged as a warning (`missing_areas/floors/labels` from the core helper) instead of silently resolving to nothing.

Out of scope, as agreed: dedup of overlapping native HA groups passed raw to a transport (level (2)), zones/geofencing, categories.

### Verification

- 35 new tests in `tests/components/supernotify/test_target_selectors.py`: `Target` helpers, discovery (cached / fallback / failure), resolution against real area/floor/label registries, delivery option matrix, end-to-end `generate_targets` in both modes, override targets, native pass-through in `notify_entity`, `action_target()` helper.
- Full suite: 1235 passed on both lanes (py3.13 / HA 2026.2.3 and py3.14 / HA 2026.9.1), 96% coverage, new code 100%; ruff, mypy (both lanes) and codespell clean.
- Docs: `usage/notifying.md` (new "Area, Floor and Label Targets" section), `configuration/deliveries.md`, `transports/index.md`.

Not yet exercised on a live HA — happy to run it against my instance (chime by area is my own use case) before merge if you'd like an E2E confirmation first.
