### PR TITLE
Upload zip release asset for download tracking

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,16 @@ jobs:
       with:
         fetch-depth: 0
         ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag_name || github.ref }}
+    - name: Package release zip
+      if: github.event_name == 'release'
+      run: |
+        cd custom_components
+        zip -r "${{ github.workspace }}/${{ github.event.release.tag_name }}.zip" supernotify
+    - name: Upload release zip asset
+      if: github.event_name == 'release'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release upload "${{ github.event.release.tag_name }}" "${{ github.event.release.tag_name }}.zip" --clobber
     - name: HACS Action
       uses: "hacs/action@1ebf01c408f29afcb6406bd431bc98fd8cbb15aa"
       with:


### PR DESCRIPTION
## Summary
- Releases currently have zero uploaded assets (confirmed via API), so HACS download stats can never be captured for this repo regardless of the asset-name template used downstream
- Adds a step that zips `custom_components/supernotify` as `<tag>.zip` and uploads it to the release via `gh release upload` on `release: published` (the trigger already existed)

## Test plan
- [ ] Publish a release and confirm the `<tag>.zip` asset appears attached
- [ ] Confirm the `hacs-downloads` capture script picks up a non-zero download count after a few downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)